### PR TITLE
Python 2+3 version variable and test macros

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -162,6 +162,28 @@ actions:
             popd
         }
         python_install
+    - python_test: |
+        function python_test() {
+            [[ -d py2build ]] && cd py2build
+
+            if [[ -z $PYTHONPATH ]]; then
+                export PYTHONPATH=%installroot%/usr/lib/python%python2_version%/site-packages:$PWD/build/lib
+                local do_unset=true
+            fi
+
+            if [[ -z $1 ]]; then
+                python2 setup.py test || exit 1
+            elif [[ $1 =~ .*\.py$ ]]; then
+                python2 "$@" || exit 1
+            else
+                "$@" || exit
+            fi
+
+            [[ $do_unset ]] && unset PYTHONPATH
+
+            [[ -d ../py2build ]] && cd ..
+        }
+        python_test
     - python_compile: |
         function python_compile() {
             if [ -z "$1" ]; then
@@ -206,6 +228,28 @@ actions:
             popd
         }
         python3_install
+    - python3_test: |
+        function python3_test() {
+            [[ -d py3build ]] && cd py3build
+
+            if [[ -z $PYTHONPATH ]]; then
+                export PYTHONPATH=%installroot%/usr/lib/python%python3_version%/site-packages:$PWD/build/lib
+                local do_unset=true
+            fi
+
+            if [[ -z $1 ]]; then
+                python3 setup.py test || exit 1
+            elif [[ $1 =~ .*\.py$ ]]; then
+                python3 "$@" || exit 1
+            else
+                "$@" || exit
+            fi
+
+            [[ $do_unset ]] && unset PYTHONPATH
+
+            [[ -d ../py3build ]] && cd ..
+        }
+        python3_test
     - python3_compile: |
         function python3_compile() {
             if [ -z "$1" ]; then
@@ -274,3 +318,8 @@ defines:
     # Get "Current" kernel version
     - kernel_version_current: |
         $(echo "$(basename `readlink /usr/lib/kernel/default-current` | cut -d '.' -f 4,5,6)".current)
+    # Get python 2 & 3 version
+    - python2_version: |
+        $(python2 --version 2>&1 | sed -r 's|^Python (.*)\..*$|\1|')
+    - python3_version: |
+        $(python3 --version 2>&1 | sed -r 's|^Python (.*)\..*$|\1|')


### PR DESCRIPTION
**Variable Macros** (used in the below macros)
- `%python2_version%` returns **2.7** for Python 2.7.x
- `%python3_version%` returns **3.6** for Python 3.6.x

**Actionable Macros** (python unit tests)
`%python_test` and `%python3_test`

If the `PYTHONPATH` environment variable is not set, the macro will do it
The following cases are handled:

1. The macro is called without parameters -> use default test function
e.g.: `%python_test` -> `python setup.py test`

2. The macro is called with a python script (`.py`) as parameter -> execute the script with the specified version of python
e.g.: `%python3_test selftest.py -v` -> `python3 selftest.py -v`

3. The macro is called with something else as parameter -> execute the command "as it is"
e.g.: `%python_test py.test -k 'not this_test'` -> `py.test -k 'not this_test'`

The macros will look for the "standard" build directories `py2build` or `py3build` and be executed in the current directory if they can't find it, so they can also be used in packages build with autotools for example.

Signed-off-by: Pierre-Yves <pyu@riseup.net>