### PR TITLE
python_test macros: also support parameters starting with a dash

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -173,7 +173,7 @@ actions:
 
             if [[ -z $1 ]]; then
                 python2 setup.py test || exit 1
-            elif [[ $1 =~ .*\.py$ ]]; then
+            elif [[ $1 =~ .*\.py$ ]] || [[ $1 == \-* ]]; then
                 python2 "$@" || exit 1
             else
                 "$@" || exit
@@ -239,7 +239,7 @@ actions:
 
             if [[ -z $1 ]]; then
                 python3 setup.py test || exit 1
-            elif [[ $1 =~ .*\.py$ ]]; then
+            elif [[ $1 =~ .*\.py$ ]] || [[ $1 == \-* ]]; then
                 python3 "$@" || exit 1
             else
                 "$@" || exit


### PR DESCRIPTION
This allows calling python with options for example

```    
    %python_test -m tornado.test.runtests --verbose
    %python3_test -m tornado.test.runtests --verbose
```
Will result in (but also going in the correct location and setting PYTHONPATH)
```    
    python2 -m tornado.test.runtests --verbose
    python3 -m tornado.test.runtests --verbose
```


Signed-off-by: Pierre-Yves <pyu@riseup.net>