### PR TITLE
Adjust width-param so ybump doesn't set summary to 80 cols

### DIFF
--- a/ybump
+++ b/ybump
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     try:
         with open(sys.argv[1], 'w') as fp:
             ruamel.yaml.round_trip_dump(
-                data, fp, indent=4, block_seq_indent=4,
+                data, fp, indent=4, block_seq_indent=4, width=200,
                 top_level_colon_align=True, prefix_colon=' ')
     except Exception as e:
         print("Error writing file, may need to reset it.")


### PR DESCRIPTION
Without the parameter "string"s like the summary in a package.yml will get a line break after 80 columns when using "make bump".
This sets the "width"-parameter to '200' to avoid this (thus matching yupdate.py).
I would also be open to setting this even higher if need be.