### PR TITLE
Ensure LTO for GCC runs in parallel

### DIFF
--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -41,7 +41,8 @@ SIZE_FLAGS = "-Os"
 SIZE_FLAGS_CLANG = "-O2"
 
 # Allow optimizing for lto
-LTO_FLAGS = "-flto"
+LTO_FLAGS = "-flto=%YJOBS%"
+LTO_FLAGS_CLANG = "-flto"
 
 # Allow optimizing for thin-lto
 THIN_LTO_FLAGS = "-flto=thin"
@@ -114,7 +115,10 @@ class Flags:
                 else:
                     newflags.extend(SIZE_FLAGS.split(" "))
         elif opt_type == "lto":
-            newflags.extend(LTO_FLAGS.split(" "))
+            if clang:
+                newflags.extend(LTO_FLAGS_CLANG.split(" "))
+            else:
+                newflags.extend(LTO_FLAGS.split(" "))
         elif opt_type == "unroll-loops":
             newflags.extend(UNROLL_LOOPS_FLAGS.split(" "))
         elif opt_type == "runpath":


### PR DESCRIPTION
GCC's documentation states that by default lto uses 1 job, it can be optionally overridden
with n number of jobs to run in parallel. Pass `-flto=%YJOBS%` when building with GCC LTO to
reduce compilation time.

Clang does not support this and instead uses thin lto for concurrency. Split LTO flags for GCC
and Clang into different variables.

Signed-off-by: Joey Riches <josephriches@gmail.com>