### PR TITLE
Profile instrumentation flags must also be added to LDFLAGS

### DIFF
--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -423,6 +423,9 @@ class YpkgContext:
         self.build.cxxflags = Flags.pgo_gen_flags(self.build.cxxflags,
                                                   pgo_dir,
                                                   self.spec.pkg_clang)
+        self.build.ldflags = Flags.pgo_gen_flags(self.build.ldflags,
+                                                  pgo_dir,
+                                                  self.spec.pkg_clang)
 
     def enable_pgo_use(self):
         """ Enable PGO use step """


### PR DESCRIPTION
Both GCC and Clang documentation states that instrumentation flags
must be used both when compiling and linking with instrumentation.
Previously some packages failed to build with PGO with errors similar
to this;

undefined reference to `__gcov_time_profiler_counter'

A poor workaround was to add `-lgcov` to LDFLAGS, however, this was much
slower and gave poorer optimization than by simply passing instrumentation
flags to the linker.

It is not neccessary pass PGO use flags to the linker.

This fixes PGO'ing: R, chromium, notepadqq and a bunch of other packages.

Signed-off-by: Joey Riches <josephriches@gmail.com>