### PR TITLE
Add avx256 flag to Flags.optimize_flags

### DIFF
--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -127,6 +127,9 @@ class Flags:
             newflags.extend(THIN_LTO_FLAGS.split(" "))
             if not clang:
                 newflags.extend(GOLD_LINKER_FLAGS.split(" "))
+        elif opt_type == "avx256":
+            #flag is handled in init_avx2
+            pass
         else:
             console_ui.emit_warning("Flags", "Unknown optimization: {}".
                                     format(opt_type))


### PR DESCRIPTION
When setting the avx256 optimization option, the code gives an unnecessary warning that the optimization flag does not exist. This patch resolves this by a simple pass in optimize_flags.