### PR TITLE
support updating package.ymls that use git sources

### DIFF
--- a/yupdate
+++ b/yupdate
@@ -11,40 +11,28 @@
 #  (at your option) any later version.
 #
 
+import argparse
 import sys
 import ruamel.yaml
 import os
 import subprocess
 import pisi.version
 
+parser = argparse.ArgumentParser()
+parser.add_argument("version", type=str, help="new version of package")
+parser.add_argument("url", type=str, help="url to new package version")
+parser.add_argument("--tag-prefix", type=str, help="git version tag prefix [default: v]", default="v")
+parser.add_argument("--yml", type=str, help="path to package yml config [default: ./package.yml]", default="package.yml")
 
 def usage(msg=None, ex=1):
     if msg:
         print(msg)
     else:
-        print("Usage: %s [version] [url]" % sys.argv[0])
+        parser.print_help()
     sys.exit(ex)
 
-if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        usage()
-
-    ymlfile = "package.yml"
-    if not os.path.exists(ymlfile):
-        usage("Specified file does not exist")
-    if not ymlfile.endswith(".yml"):
-        usage("%s does not look like a valid package.yml file")
-
-    newversion = sys.argv[1]
-    try:
-        d = pisi.version.Version(newversion)
-    except Exception as e:
-        print("Problematic version string: %s" % e)
-        sys.exit(1)
-
-    url = sys.argv[2]
-    file = url.split("/")[-1]
-
+def shasum(url):
+    fname = os.path.basename(url)
     try:
         r = os.system("wget \"%s\"" % url)
     except:
@@ -54,16 +42,38 @@ if __name__ == "__main__":
         print("Failed to download file")
         sys.exit(1)
 
-    sha256 = subprocess.check_output(["sha256sum",  file]).split()[0].strip()
+    sha256 = subprocess.check_output(["sha256sum",  fname]).split()[0].strip()
+    os.unlink(fname)
+    return sha256
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    ymlfile = args.yml
+    if not os.path.exists(ymlfile):
+        usage("Specified file does not exist")
+    if not ymlfile.endswith(".yml"):
+        usage("%s does not look like a valid package.yml file" % ymlfile)
+
+    newversion = args.version
+    try:
+        d = pisi.version.Version(newversion)
+    except Exception as e:
+        print("Problematic version string: %s" % e)
+        sys.exit(1)
+
+    url = args.url
+    if not url.startswith("git|"):
+        source = {url: shasum(url)}
+    else:
+        source = {url: args.tag_prefix + newversion}
 
     with open(ymlfile, "r") as infile:
         data = ruamel.yaml.round_trip_load(infile)
     data['source'] = sources = []
-    sources.append({url: sha256})
+    sources.append(source)
     data['release'] += 1
     data['version'] = newversion
-
-    os.unlink(file)
 
     try:
         with open(ymlfile, 'w') as fp:


### PR DESCRIPTION
### changes

* Updates `yupdate` to support updating `package.yml`s that are using `git` sources as the url.
* Adds `--yml` argument so that the `if` block at the top of the main function is used.

### testing

testing showing `yupdate` checks for `package.yml` existence and that the file must have the extension `.yml`

```
isaac@xps13 ~/packaging/hub $ ../../git/etc/ypkg/yupdate 2.14.2 "git|https://github.com/github/hub.git" --yml does-not-exist.yml
Specified file does not exist
isaac@xps13 ~/packaging/hub $ cp package.{yml,yaml}
isaac@xps13 ~/packaging/hub $ ../../git/etc/ypkg/yupdate 2.14.2 "git|https://github.com/github/hub.git" --yml package.yaml 
package.yaml does not look like a valid package.yml file
```

testing on a repo that uses a `git` source:

```
isaac@xps13 ~/packaging/hub $ pwd
/home/isaac/packaging/hub
isaac@xps13 ~/packaging/hub $ g diff package.yml
isaac@xps13 ~/packaging/hub $ ../../git/etc/ypkg/yupdate 2.14.2 "git|https://github.com/github/hub.git"
isaac@xps13 ~/packaging/hub $ g diff package.yml 
diff --git a/package.yml b/package.yml
index d50ac56..0ae385e 100644
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : hub
-version    : 2.10.0
-release    : 10
+version    : 2.14.2
+release    : 11
 source     :
-    - git|https://github.com/github/hub.git : v2.10.0
+    - git|https://github.com/github/hub.git : v2.14.2
 license    : MIT
 component  : system.utils
 summary    : A command line tool that wraps git in order to extend it with extra features and commands that make working with GitHub easier
isaac@xps13 ~/packaging/hub $ 
```

testing on a standard `package.yml` (note no version update so checksum remains the same)

```
isaac@xps13 ~/packaging/Zoom $ pwd
/home/isaac/packaging/Zoom
isaac@xps13 ~/packaging/Zoom $ g diff package.yml
isaac@xps13 ~/packaging/Zoom $ ../../git/etc/ypkg/yupdate 5.0.408598.0517 "https://zoom.us/client/latest/zoom_amd64.deb"
--2020-05-23 15:34:32--  https://zoom.us/client/latest/zoom_amd64.deb
Resolving zoom.us... 52.202.62.196
Connecting to zoom.us|52.202.62.196|:443... connected.
HTTP request sent, awaiting response... 302 
Location: https://d11yldzmag5yn.cloudfront.net/prod/5.0.408598.0517/zoom_amd64.deb?_x_zm_rtaid=VT4hlVtDTPC98ECTzgwvTg.1590273272881.07c760c538552eaa662bddf2cb510c5b&_x_zm_rhtaid=149 [following]
--2020-05-23 15:34:32--  https://d11yldzmag5yn.cloudfront.net/prod/5.0.408598.0517/zoom_amd64.deb?_x_zm_rtaid=VT4hlVtDTPC98ECTzgwvTg.1590273272881.07c760c538552eaa662bddf2cb510c5b&_x_zm_rhtaid=149
Resolving d11yldzmag5yn.cloudfront.net... 13.227.77.210, 13.227.77.169, 13.227.77.20, ...
Connecting to d11yldzmag5yn.cloudfront.net|13.227.77.210|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 41595972 (40M) [binary/octet-stream]
Saving to: ‘zoom_amd64.deb’

zoom_amd64.deb                                 100%[==================================================================================================>]  39.67M  10.2MB/s    in 3.8s    

2020-05-23 15:34:36 (10.4 MB/s) - ‘zoom_amd64.deb’ saved [41595972/41595972]

isaac@xps13 ~/packaging/Zoom $ g diff package.yml
diff --git a/package.yml b/package.yml
index 5e00ffe..ade17a9 100644
--- a/package.yml
+++ b/package.yml
@@ -1,6 +1,6 @@
 name       : zoom
 version    : 5.0.408598.0517
-release    : 1
+release    : 2
 source     :
     - https://zoom.us/client/latest/zoom_amd64.deb : 65e63f756a78fabd3d848f2ce16d47c492fb12fd917f79e60cb2025b4d1e2089
 license    : see https://zoom.us
isaac@xps13 ~/packaging/Zoom $ 
```