### PR TITLE
Add python3_avx2_lib_shift macro and and add extra check for avx2_lib_shift

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -324,6 +324,8 @@ actions:
           mv %installroot%/%libdir%/* $PKG_BUILD_DIR/haswell
           mv $PKG_BUILD_DIR/haswell %installroot%/%libdir%/
         fi
+    - python3_avx2_lib_shift: |
+        find %installroot%/usr/lib/python%python3_version%/ -name '*.so' -exec sh -c 'mv "$0" "${0%.so}.so.avx2"' {} \;
 defines:
     - CONFOPTS: |
         --prefix=%PREFIX% --build=%HOST% --libdir=%libdir% --mandir=/usr/share/man \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -319,9 +319,11 @@ actions:
             echo "\n\nError: Profiling requested by ypkg but doesn't exist\n\n"
         fi
     - avx2_lib_shift: |
-        install -dm00755 $PKG_BUILD_DIR/haswell
-        mv %installroot%/%libdir%/* $PKG_BUILD_DIR/haswell
-        mv $PKG_BUILD_DIR/haswell %installroot%/%libdir%/
+        if [ -d "%installroot%/%libdir%" ]; then
+          install -dm00755 $PKG_BUILD_DIR/haswell
+          mv %installroot%/%libdir%/* $PKG_BUILD_DIR/haswell
+          mv $PKG_BUILD_DIR/haswell %installroot%/%libdir%/
+        fi
 defines:
     - CONFOPTS: |
         --prefix=%PREFIX% --build=%HOST% --libdir=%libdir% --mandir=/usr/share/man \


### PR DESCRIPTION
The python3_avx2_lib_shift macro will append a .avx2 extension to all python3 .so files in the $installdir. This is intended to be the last command to run as part of the the install step for avx2 builds. This allows a patched python to load the optimized .so.avx2 if a supported cpu is found.

An extra check is added to avx2_lib_shift to ensure it doesn't try and move around files which don't exist. Without this change avx2_lib_shift tries to run automatically after install and would fail for python module avx2 builds.

Generally, this is intended to be good-enough until YPKG3 as I don't want to import too much resources into something which will soon be swapped out. Hopefully for YPKG3 the equivalent of python3_avx2_lib_shift would be able to be run automagically.