### PR TITLE
Add optional linker flag icf={safe,all} to optimizations

### DIFF
--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "PACKAGE\.YML" "5" "September 2020" "" ""
+.TH "PACKAGE\.YML" "5" "August 2021" "" ""
 .
 .SH "NAME"
 \fBpackage\.yml\fR \- Solus package build format
@@ -331,6 +331,12 @@ Valid keys are restricted to:
 .
 .IP "\(bu" 4
 \fBlto\fR: Enable Link Time Optimization
+.
+.IP "\(bu" 4
+\fBicf\-safe\fR: Enable \fB\-Wl,\-\-icf=safe\fR to utilize the safe Identical Code Folding linker optimization\.
+.
+.IP "\(bu" 4
+\fBicf\-all\fR: Enable \fB\-Wl,\-\-icf=all\fR to utilize the Identical Code Folding linker optimization\.
 .
 .IP "" 0
 

--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "PACKAGE\.YML" "5" "August 2021" "" ""
+.TH "PACKAGE\.YML" "5" "September 2021" "" ""
 .
 .SH "NAME"
 \fBpackage\.yml\fR \- Solus package build format
@@ -337,6 +337,9 @@ Valid keys are restricted to:
 .
 .IP "\(bu" 4
 \fBicf\-all\fR: Enable \fB\-Wl,\-\-icf=all\fR to utilize the Identical Code Folding linker optimization\.
+.
+.IP "\(bu" 4
+\fBfunction\-sections\fR: Enables \fB\-ffunction\-sections\fR to generate a seperate ELF section for each function\. Recommended for icf with gcc\.
 .
 .IP "" 0
 

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -376,6 +376,7 @@ additional functionality.</p>
 <li> <code>lto</code>: Enable Link Time Optimization</li>
 <li> <code>icf-safe</code>: Enable <code>-Wl,--icf=safe</code> to utilize the safe Identical Code Folding linker optimization.</li>
 <li> <code>icf-all</code>: Enable <code>-Wl,--icf=all</code> to utilize the Identical Code Folding linker optimization.</li>
+<li> <code>function-sections</code>: Enables <code>-ffunction-sections</code> to generate a seperate ELF section for each function. Recommended for icf with gcc.</li>
 </ul>
 </li>
 <li><p><code>networking</code> [boolean]</p>
@@ -577,7 +578,7 @@ builddeps:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2021</li>
+    <li class='tc'>September 2021</li>
     <li class='tr'>package.yml(5)</li>
   </ol>
 

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -374,6 +374,8 @@ additional functionality.</p>
 <li> <code>avx256</code>: Disables <code>-mprefer-vector-width=128</code> in avx2 builds</li>
 <li> <code>thin-lto</code>: Enable Thin Link Time Optimization</li>
 <li> <code>lto</code>: Enable Link Time Optimization</li>
+<li> <code>icf-safe</code>: Enable <code>-Wl,--icf=safe</code> to utilize the safe Identical Code Folding linker optimization.</li>
+<li> <code>icf-all</code>: Enable <code>-Wl,--icf=all</code> to utilize the Identical Code Folding linker optimization.</li>
 </ul>
 </li>
 <li><p><code>networking</code> [boolean]</p>
@@ -575,7 +577,7 @@ builddeps:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>September 2020</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>package.yml(5)</li>
   </ol>
 

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -316,6 +316,8 @@ additional functionality.
      * `avx256`: Disables `-mprefer-vector-width=128` in avx2 builds
      * `thin-lto`: Enable Thin Link Time Optimization
      * `lto`: Enable Link Time Optimization
+     * `icf-safe`: Enable `-Wl,--icf=safe` to utilize the safe Identical Code Folding linker optimization.
+     * `icf-all`: Enable `-Wl,--icf=all` to utilize the Identical Code Folding linker optimization.
 
 * `networking` [boolean]
 

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -318,6 +318,7 @@ additional functionality.
      * `lto`: Enable Link Time Optimization
      * `icf-safe`: Enable `-Wl,--icf=safe` to utilize the safe Identical Code Folding linker optimization.
      * `icf-all`: Enable `-Wl,--icf=all` to utilize the Identical Code Folding linker optimization.
+     * `function-sections`: Enables `-ffunction-sections` to generate a seperate ELF section for each function. Recommended for icf with gcc.
 
 * `networking` [boolean]
 

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -52,6 +52,10 @@ ICF_ALL_FLAGS = "-Wl,--icf=all"
 # Allow optimizing for ICF safe
 ICF_SAFE_FLAGS = "-Wl,--icf=safe"
 
+# Generate a seperate ELF section for each function
+# Recommended for use with gcc/gold ICF
+FUNCTION_SECTION_FLAGS = "-ffunction-sections"
+
 # Use gold linker with GCC
 GOLD_LINKER_FLAGS = "-fuse-ld=gold"
 
@@ -141,6 +145,8 @@ class Flags:
             newflags.extend(ICF_ALL_FLAGS.split(" "))
             if not clang:
                 newflags.extend(GOLD_LINKER_FLAGS.split(" "))
+        elif opt_type == "function-sections":
+            newflags.extend(FUNCTION_SECTION_FLAGS.split(" "))
         else:
             console_ui.emit_warning("Flags", "Unknown optimization: {}".
                                     format(opt_type))

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -46,6 +46,12 @@ LTO_FLAGS = "-flto"
 # Allow optimizing for thin-lto
 THIN_LTO_FLAGS = "-flto=thin"
 
+# Allow optimizing for ICF all (identical code folding)
+ICF_ALL_FLAGS = "-Wl,--icf=all"
+
+# Allow optimizing for ICF safe
+ICF_SAFE_FLAGS = "-Wl,--icf=safe"
+
 # Use gold linker with GCC
 GOLD_LINKER_FLAGS = "-fuse-ld=gold"
 
@@ -125,6 +131,14 @@ class Flags:
             newflags = Flags.filter_flags(f, SYMBOLIC_FLAGS)
         elif opt_type == "thin-lto":
             newflags.extend(THIN_LTO_FLAGS.split(" "))
+            if not clang:
+                newflags.extend(GOLD_LINKER_FLAGS.split(" "))
+        elif opt_type == "icf-safe":
+            newflags.extend(ICF_SAFE_FLAGS.split(" "))
+            if not clang:
+                newflags.extend(GOLD_LINKER_FLAGS.split(" "))
+        elif opt_type == "icf-all":
+            newflags.extend(ICF_ALL_FLAGS.split(" "))
             if not clang:
                 newflags.extend(GOLD_LINKER_FLAGS.split(" "))
         else:
@@ -347,7 +361,7 @@ class YpkgContext:
             self.build.cc = "{}-gcc".format(self.pconfig.values.build.host)
             self.build.cxx = "{}-g++".format(self.pconfig.values.build.host)
             if self.spec.pkg_optimize:
-                if "thin-lto" in self.spec.pkg_optimize:
+                if "thin-lto" or "icf-safe" or "icf-all" in self.spec.pkg_optimize:
                     self.build.ldflags = Flags.filter_flags(self.build.ldflags, \
                                                         NON_LD_LINKER_FLAGS)
 
@@ -363,7 +377,9 @@ class YpkgContext:
     def init_optimize(self):
         """ Handle optimize settings within the spec """
         for opt in self.spec.pkg_optimize:
-            if opt != "runpath":
+            if opt == "runpath" or opt == "icf-safe" or opt == "icf-all":
+                pass
+            else:
                 self.build.cflags = Flags.optimize_flags(self.build.cflags,
                                                         opt,
                                                         self.spec.pkg_clang)
@@ -371,7 +387,8 @@ class YpkgContext:
                                                         opt,
                                                         self.spec.pkg_clang)
             if opt == "no-bind-now" or opt == "no-symbolic" \
-                or opt == "runpath":
+                or opt == "runpath" or opt == "icf-safe"    \
+                or opt == "icf-all":
                 self.build.ldflags = Flags.optimize_flags(self.build.ldflags,
                                                           opt,
                                                           self.spec.pkg_clang)

--- a/ypkg2/ypkgspec.py
+++ b/ypkg2/ypkgspec.py
@@ -281,7 +281,7 @@ class YpkgSpec:
         if self.pkg_clang:
             extras.extend(["llvm-clang", "llvm-clang-devel"])
         if self.pkg_optimize:
-            if "thin-lto" in self.pkg_optimize and not self.pkg_clang:
+            if "thin-lto" or "icf-safe" or "icf-all" in self.pkg_optimize and not self.pkg_clang:
                 extras.extend(["binutils-gold"])
 
         man = SourceManager()


### PR DESCRIPTION
Identical code folding folds identical functions into a single copy, saving disk space.
Generally useful for large C++ applications.

Only the gold linker can handle icf when using the gcc toolchain, although icf is generally superior when using llvm/lld.

Also add support for function-sections, this is recommended for use with ICF when using gcc/gold but not strictly necessary.

icf-all is not recommended for gcc/gold but is left as an option. icf-all is generally safe for clang/lld due to -faddrsig being default in clang.

Additionally, fix a thinko where runpath wasn't being filtered from cflags/cxxflags.