### PR TITLE
Export environmental variables for pgo_gen and pgo_use build contexts

### DIFF
--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -118,6 +118,10 @@ def execute_step(context, step, step_n, work_dir):
         script.define_export("PKG_CONFIG_PATH", EMUL32PC)
     if context.avx2:
         script.define_export("AVX2BUILD", "1")
+    if context.gen_pgo:
+        script.define_export("PGO_GEN_BUILD", "1")
+    if context.use_pgo:
+        script.define_export("PGO_USE_BUILD", "1")
     extraScript = None
     endScript = None
 


### PR DESCRIPTION
This allows us to customize the build for pgo_gen and pgo_use build contexts. E.g. only setting LTO for the pgo_use step.