### PR TITLE
Add new python macros to adjust to PEP 517/518

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -277,6 +277,12 @@ actions:
             fi
         }
         python3_compile
+    # Generate a wheel file from pyproject.toml
+    - pyproject_build: |
+        python3 -m pip wheel --no-deps --use-pep517 --no-build-isolation --disable-pip-version-check --no-clean --verbose .
+    # Install generated wheel file
+    - pyproject_install: |
+        python3 -m pip install --root=%installroot% --no-deps --disable-pip-version-check --verbose --ignore-installed --no-warn-script-location --no-index --no-cache-dir *.whl
     # Make life easier with Ruby gems
     - gem_build: |
         function gem_build() {


### PR DESCRIPTION
These macros should be used when a setup.py file is not present but a pyproject.toml/setup.cfg file is.

Setuptools PEP517 tested via python-jsonschema
Poetry build system tested via yubikey-manager
Flit build system tested via python-mediafile