### PR TITLE
Implement sccache

### DIFF
--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -177,8 +177,9 @@ class ScriptGenerator:
                 self.define_export("NM", "llvm-nm")
 
         # Handle sccache. It is enabled together with ccache
-        if self.context.build.ccache and self.spec.pkg_ccache:
-            self.define_export("RUSTC_WRAPPER", "/usr/bin/sccache")
+        if os.path.exists("/usr/bin/sccache"):
+            if self.context.build.ccache and self.spec.pkg_ccache:
+                self.define_export("RUSTC_WRAPPER", "/usr/bin/sccache")
 
         if not console_ui.allow_colors:
             self.define_export("TERM", "dumb")

--- a/ypkg2/scripts.py
+++ b/ypkg2/scripts.py
@@ -176,6 +176,10 @@ class ScriptGenerator:
                 self.define_export("RANLIB", "llvm-ranlib")
                 self.define_export("NM", "llvm-nm")
 
+        # Handle sccache. It is enabled together with ccache
+        if self.context.build.ccache and self.spec.pkg_ccache:
+            self.define_export("RUSTC_WRAPPER", "/usr/bin/sccache")
+
         if not console_ui.allow_colors:
             self.define_export("TERM", "dumb")
 

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -246,7 +246,10 @@ class YpkgContext:
         # If ccache is enabled, sccache is also enabled. However, sccache
         # doesn't need to manipulate PATH, so only a log is emitted. No further
         # action is done
-        console_ui.emit_info("Build", "Enabling sccache")
+        if os.path.exists("/usr/bin/sccache"):
+            console_ui.emit_info("Build", "Enabling sccache")
+        else:
+            console_ui.emit_warning("Build", "sccache is enabled but cannot be found. Disabling sccache")
 
         return default_path
 

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -242,6 +242,12 @@ class YpkgContext:
             if os.path.exists(i):
                 console_ui.emit_info("Build", "Enabling ccache")
                 return "{}:{}".format(i, default_path)
+
+        # If ccache is enabled, sccache is also enabled. However, sccache
+        # doesn't need to manipulate PATH, so only a log is emitted. No further
+        # action is done
+        console_ui.emit_info("Build", "Enabling sccache")
+
         return default_path
 
     def get_sources_directory(self):


### PR DESCRIPTION
Integrate `sccache`, a compiler cache similar to `ccache` but can also cache Rust builds, particularly those built with the `--release` flag.

Do not merge this until `sccache` has been accepted into the Solus repo (https://dev.getsol.us/D12919).

Signed-off-by: Gavin Zhao <git@gzgz.dev>
