### PR TITLE
Allow for renaming of simple source files

### DIFF
--- a/ypkg2/sources.py
+++ b/ypkg2/sources.py
@@ -203,7 +203,7 @@ class TarSource(YpkgSource):
         YpkgSource.__init__(self)
         self.uri = uri
         self.hash = hash
-        if '#' in uri:
+        if '#' in uri: #support URI fragments for renaming sources
             self.filename = os.path.basename(uri[uri.index("#")+1:])
         else:
             self.filename = os.path.basename(uri)

--- a/ypkg2/sources.py
+++ b/ypkg2/sources.py
@@ -202,8 +202,11 @@ class TarSource(YpkgSource):
     def __init__(self, uri, hash):
         YpkgSource.__init__(self)
         self.uri = uri
-        self.filename = os.path.basename(uri)
         self.hash = hash
+        if '#' in uri:
+            self.filename = os.path.basename(uri[uri.index("#")+1:])
+        else:
+            self.filename = os.path.basename(uri)
 
     def __str__(self):
         return "%s (%s)" % (self.uri, self.hash)


### PR DESCRIPTION
This commit allows for renaming of source files by adding `#putNewNameHere.tar.gz` at the end of the source URL. This is useful when multiple of your sources have the same filename, like rocm I am packaging.
There is a complimentary solbuild patch for the same functionality.