### PR TITLE
Add manpage compression

### DIFF
--- a/ypkg2/compressdoc.py
+++ b/ypkg2/compressdoc.py
@@ -1,0 +1,120 @@
+#!/bin/true
+# -*- coding: utf-8 -*-
+#
+#  This file is part of ypkg2
+#
+#  Copyright 2022 Solus Project
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+
+import gzip
+import os
+
+compressed_exts = [
+    ".gz",
+    ".bz2",
+    ".zst"
+]
+
+def is_compressed(path):
+    """Check if a file is compressed."""
+
+    parts = os.path.splitext(path)
+    file_ext = parts[1]
+
+    if file_ext in compressed_exts:
+        return True
+
+    return False
+
+def compress_gzip(path):
+    """Compresses a single file with `gzip`.
+    
+    The original file will be deleted after compression.
+    """
+
+    # Open the file
+    in_file = open(path)
+
+    # Create the file to write to
+    out_path = "{}.gz".format(path)
+    out_file = gzip.open(out_path, "wb", 9) # Maximum compression
+
+    # Write the contents to the compressed file through gzip
+    out_file.writelines(in_file)
+
+    # Close the files
+    out_file.close()
+    in_file.close()
+
+    # Remove the original file
+    os.unlink(path)
+
+def compress_all_in_dir(path):
+    """Compress all files in a directory.
+    
+    This function iterates over all children in the
+    given directory. If the file is a regular uncompressed
+    file, it will be compressed with `gzip`.
+
+    Files that are already compressed will be ignored.
+
+    Symlinked files will have their links updated to point
+    to the new (compressed) target path.
+    """
+
+    # Iterate over each file in the directory
+    for file in os.listdir(path):
+        file_path = os.path.join(path, file)
+
+        if is_compressed(file_path):
+            continue
+
+        # Check if the file is a symlink
+        if os.path.islink(file_path):
+            # Get the link target
+            link_target = os.readlink(file_path)
+            if os.path.islink(link_target):
+                # Skip if this is pointing to another link
+                continue
+
+            # Figure out what the compressed target path is
+            new_link = "{}.gz".format(link_target)
+
+            # Re-link to the new target
+            os.unlink(file_path)
+            os.symlink(new_link, file_path)
+        elif os.path.isfile(file_path):
+            # We have a file, compress it
+            compress_gzip(file_path)
+
+def compress_man_dirs(root):
+    """Compresses manpage files recursively from the given root.
+    
+    This function iterates over all of the directories in the root,
+    and compressing the contents of directories if they look like
+    manpage directories (the directory name starts with `man`).
+
+    If a directory is not a manpage directory, call this function
+    again with the child directory as the new root.
+    """
+
+    for dir in os.listdir(root):
+        child_path = os.path.join(root, dir)
+
+        # Ignore non-directories
+        if not os.path.isdir(child_path):
+            continue
+
+        # Recurse into localized manpage dirs
+        if not dir.startswith("man"):
+            compress_man_dirs(child_path)
+            continue
+
+        # This appears to be a manpage dir,
+        # so compress everything in it
+        compress_all_in_dir(child_path)

--- a/ypkg2/compressdoc.py
+++ b/ypkg2/compressdoc.py
@@ -17,7 +17,9 @@ import os
 compressed_exts = [
     ".gz",
     ".bz2",
-    ".zst"
+    ".lz",
+    ".zst",
+    ".xz"
 ]
 
 def is_compressed(path):

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -13,6 +13,7 @@
 
 from . import console_ui
 from . import remove_prefix
+from .compressdoc import compress_man_dirs
 from .ypkgspec import YpkgSpec
 from .sources import SourceManager
 from .ypkgcontext import YpkgContext
@@ -371,6 +372,23 @@ def build_package(filename, outputDir):
                 continue
             console_ui.emit_error("Build", "{} failed for {}".format(step, spec.pkg_name))
             sys.exit(1)
+
+    # Compress manpage files
+    console_ui.emit_info("Man", "Compressing manpages...")
+    man_dirs = [
+        "{}/usr/share/man".format(ctx.get_install_dir()),
+        "{}/usr/man".format(ctx.get_install_dir()),
+    ]
+    for dir in man_dirs:
+        if not os.path.exists(dir):
+            continue
+
+        try:
+            compress_man_dirs(dir)
+            console_ui.emit_success("Man", "Manpages compressed")
+        except Exception as e:
+            console_ui.emit_warning("Man", "Failed to compress man pages in '{}'".format(dir))
+            print(e)
 
     # Add user patterns - each consecutive package has higher priority than the
     # package before it, ensuring correct levels of control

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -13,7 +13,7 @@
 
 from . import console_ui
 from . import remove_prefix
-from .compressdoc import compress_info_pages, compress_manpages
+from .compressdoc import compress_info_pages, compress_man_pages
 from .ypkgspec import YpkgSpec
 from .sources import SourceManager
 from .ypkgcontext import YpkgContext
@@ -385,7 +385,7 @@ def build_package(filename, outputDir):
 
         console_ui.emit_info("Man", "Compressing manpages in '{}'...".format(dir))
         try:
-            (compressed, saved) = compress_manpages(dir)
+            (compressed, saved) = compress_man_pages(dir)
             console_ui.emit_success("Man", "Compressed {} file(s), saving {}".format(compressed, humanize(saved)))
         except Exception as e:
             console_ui.emit_warning("Man", "Failed to compress man pages in '{}'".format(dir))

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -13,7 +13,7 @@
 
 from . import console_ui
 from . import remove_prefix
-from .compressdoc import compress_man_dirs
+from .compressdoc import compress_info_pages, compress_manpages
 from .ypkgspec import YpkgSpec
 from .sources import SourceManager
 from .ypkgcontext import YpkgContext
@@ -384,11 +384,20 @@ def build_package(filename, outputDir):
             continue
 
         try:
-            compress_man_dirs(dir)
+            compress_manpages(dir)
             console_ui.emit_success("Man", "Manpages compressed")
         except Exception as e:
             console_ui.emit_warning("Man", "Failed to compress man pages in '{}'".format(dir))
             print(e)
+    
+    # Now try to compress any info pages
+    console_ui.emit_info("Man", "Compressing info pages...")
+    try:
+        compress_info_pages("{}/usr/share/info".format(ctx.get_install_dir()))
+        console_ui.emit_success("Man", "Info pages compressed")
+    except Exception as e:
+        console_ui.emit_warning("Man", "Failed to compress info pages")
+        print(e)
 
     # Add user patterns - each consecutive package has higher priority than the
     # package before it, ensuring correct levels of control

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -24,6 +24,7 @@ from . import metadata
 from .dependencies import DependencyResolver
 from . import packager_name, packager_email
 from . import EMUL32PC
+from .ui import humanize
 
 import ypkg2
 
@@ -374,7 +375,6 @@ def build_package(filename, outputDir):
             sys.exit(1)
 
     # Compress manpage files
-    console_ui.emit_info("Man", "Compressing manpages...")
     man_dirs = [
         "{}/usr/share/man".format(ctx.get_install_dir()),
         "{}/usr/man".format(ctx.get_install_dir()),
@@ -383,21 +383,24 @@ def build_package(filename, outputDir):
         if not os.path.exists(dir):
             continue
 
+        console_ui.emit_info("Man", "Compressing manpages in '{}'...".format(dir))
         try:
-            compress_manpages(dir)
-            console_ui.emit_success("Man", "Manpages compressed")
+            (compressed, saved) = compress_manpages(dir)
+            console_ui.emit_success("Man", "Compressed {} file(s), saving {}".format(compressed, humanize(saved)))
         except Exception as e:
             console_ui.emit_warning("Man", "Failed to compress man pages in '{}'".format(dir))
             print(e)
     
     # Now try to compress any info pages
-    console_ui.emit_info("Man", "Compressing info pages...")
-    try:
-        compress_info_pages("{}/usr/share/info".format(ctx.get_install_dir()))
-        console_ui.emit_success("Man", "Info pages compressed")
-    except Exception as e:
-        console_ui.emit_warning("Man", "Failed to compress info pages")
-        print(e)
+    info_dir = "{}/usr/share/info".format(ctx.get_install_dir())
+    if os.path.exists(info_dir):
+        console_ui.emit_info("Man", "Compressing info pages...")
+        try:
+            (compressed, saved) = compress_info_pages(info_dir)
+            console_ui.emit_success("Man", "Compressed {} file(s), saving {}".format(compressed, humanize(saved)))
+        except Exception as e:
+            console_ui.emit_warning("Man", "Failed to compress info pages")
+            print(e)
 
     # Add user patterns - each consecutive package has higher priority than the
     # package before it, ensuring correct levels of control

--- a/ypkg2/ui.py
+++ b/ypkg2/ui.py
@@ -3,14 +3,13 @@
 #
 #  This file is part of ypkg2
 #
-#  Copyright 2015-2020 Solus Project
+#  Copyright 2015-2022 Solus Project
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 #
-
 
 class AnsiColors:
     """ ANSI sequences for color output """
@@ -91,3 +90,14 @@ class YpkgUI:
         else:
             print("{}[{}]{} {}".format(AnsiColors.GREEN, key,
                   AnsiColors.RESET, success))
+
+suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]
+def humanize(nbytes):
+    i = 0
+
+    while nbytes >= 1024 and i < len(suffixes)-1:
+        nbytes /= 1024.
+        i += 1
+
+    f = ("%.2f" % nbytes).rstrip("0").rstrip(".")
+    return "{} {}".format(f, suffixes[i])

--- a/ypkg2/ui.py
+++ b/ypkg2/ui.py
@@ -91,8 +91,18 @@ class YpkgUI:
             print("{}[{}]{} {}".format(AnsiColors.GREEN, key,
                   AnsiColors.RESET, success))
 
+
 suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]
+
+
 def humanize(nbytes):
+    """
+    Takes a number of bytes and returns a string that
+    is formatted to the biggest unit that makes sense.
+
+    For example, 63,456 bytes would return 63.46 KB.
+    """
+
     i = 0
 
     while nbytes >= 1024 and i < len(suffixes)-1:


### PR DESCRIPTION
With this, ypkg will compress manpage and info files with gzip at maximum compression. Symlinks will be updated to point to the new compressed files.

When compression has been applied, the output also includes how many files were compressed, and the amount of the space  that was saved by compression.

This has been tested with the `nano` and `xz` packages both with `fakeroot ypkg-build ...` and with `solbuild` after patching Ypkg.

Fixes #30