### PR TITLE
Make sure lib32/cmake/ files get added to 32-bit-devel packages

### DIFF
--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -204,7 +204,8 @@ class PackageGenerator:
         self.add_pattern("/usr/share/cmake/", "devel")
         self.add_pattern("/usr/lib64/cmake/", "devel")
         self.add_pattern("/usr/lib/cmake/", "devel")
-        self.add_pattern("/usr/lib32/cmake/", "32bit-devel")
+        self.add_pattern("/usr/lib32/cmake/", "32bit-devel",
+                         priority=PRIORITY_DEFAULT+1)
 
         # Haskell
         self.add_pattern("/usr/lib64/ghc-*/*/*.a", "devel")


### PR DESCRIPTION
Without the priority bump the files land in the main `32-bit` package instead. See e.g. here: https://dev.getsol.us/R1476:a62f8083e08d340ad527ce359056b809dd0c66b2