### PR TITLE
rc: new Haskell macros for Nix-style Cabal builds

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -77,7 +77,6 @@ actions:
                                            --sysconfdir=/etc \
                                            --disable-tests \
                                            -O2 \
-                                           --ghc-options="-H128m" \
                                            "$@"
         }
         haskell_configure

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -75,8 +75,8 @@ actions:
             runhaskell Setup configure --prefix=%PREFIX% \
                                        --libdir=%libdir% \
                                        --libsubdir="\$compiler/\$pkgid" \
-                                       --libexecdir="%libdir%/\$compiler/\$pkgid" \
-                                       --dynlibdir=%libdir% \
+                                       --libexecdir=%libdir%/%PKGNAME% \
+                                       --dynlibdir="%libdir%/\$compiler/\$pkgid" \
                                        --datadir=/usr/share \
                                        --datasubdir=%PKGNAME% \
                                        --docdir="/usr/share/doc/%PKGNAME%" \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -75,10 +75,12 @@ actions:
             runhaskell Setup configure --prefix=%PREFIX% \
                                        --libdir=%libdir% \
                                        --libsubdir='$compiler/$pkgid' \
-                                       --sysconfdir=/etc \
+                                       --libexecdir='%libdir%/$compiler/$pkgid' \
+                                       --dynlibdir=%libdir% \ 
                                        --datadir=/usr/share \
-                                       --datasubdir='$pkg' \
-                                       --docdir='/usr/share/doc/$pkg' \
+                                       --datasubdir=%PKGNAME% \
+                                       --docdir='/usr/share/doc/%PKGNAME%' \
+                                       --sysconfdir=/etc \
                                        --disable-tests \
                                        --enable-executable-dynamic \
                                        --enable-shared \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -72,12 +72,11 @@ actions:
                 echo "main = defaultMain" >> Setup.hs
             fi
             runhaskell Setup configure --prefix=%PREFIX% \
-                                           --libdir=%libdir% \
-                                           --libsubdir="\$compiler/\$pkgid" \
-                                           --sysconfdir=/etc \
-                                           --disable-tests \
-                                           -O2 \
-                                           "$@"
+                                       --libdir=%libdir% \
+                                       --sysconfdir=/etc \
+                                       --disable-tests \
+                                       -O2 \
+                                       "$@"
         }
         haskell_configure
     - haskell_build: |

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -76,10 +76,8 @@ actions:
                                            --libsubdir="\$compiler/\$pkgid" \
                                            --sysconfdir=/etc \
                                            --disable-tests \
-                                           --enable-executable-dynamic \
-                                           --enable-shared \
                                            -O2 \
-                                           --ghc-options="-fPIC -H128m" \
+                                           --ghc-options="-H128m" \
                                            "$@"
         }
         haskell_configure
@@ -97,7 +95,7 @@ actions:
         function cabal_configure() {
             export GHCV=$(ghc --numeric-version)
             cabal update
-            cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-fPIC -H128m %JOBS%" "$@"
+            cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-H128m %JOBS%" "$@"
             %haskell_configure --disable-executable-dynamic \
                                --package-db=$HOME/.cabal/store/ghc-$GHCV/package.db \
                                "$@"

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -64,7 +64,6 @@ actions:
         }
         apply_patches
     # Make life easier with Haskell/Cabal
-    # And yes, %JOBS% needs to be specified two times.
     - haskell_configure: |
         function haskell_configure() {
             if [[ ! -e Setup.hs ]] && [[ ! -e Setup.lhs ]]; then
@@ -72,27 +71,25 @@ actions:
                 echo "import Distribution.Simple" > Setup.hs
                 echo "main = defaultMain" >> Setup.hs
             fi
-            runhaskell Setup.*hs configure --prefix=%PREFIX% \
+            runhaskell Setup configure --prefix=%PREFIX% \
                                            --libdir=%libdir% \
                                            --libsubdir="\$compiler/\$pkgid" \
                                            --sysconfdir=/etc \
                                            --disable-tests \
-                                           --disable-executable-static \
                                            --enable-executable-dynamic \
                                            --enable-shared \
-                                           --disable-static \
                                            -O2 \
-                                           --ghc-options="-fPIC -H128m %JOBS%" \
+                                           --ghc-options="-fPIC -H128m" \
                                            "$@"
         }
         haskell_configure
     - haskell_build: |
-        runhaskell Setup.*hs build %JOBS%
+        runhaskell Setup build %JOBS%
     - haskell_install: |
-        runhaskell Setup.*hs copy --destdir=$installdir
+        runhaskell Setup copy --destdir=$installdir
     - haskell_register: |
         export GHCV=$(ghc --numeric-version)
-        runhaskell Setup.*hs register --gen-pkg-config=$package-$version.conf
+        runhaskell Setup register --gen-pkg-config=$package-$version.conf
         install -D -m 00644 $package-$version.conf $installdir%libdir%/ghc-$GHCV/package.conf.d/$package-$version.conf
     # Configures a Cabal project that requires online dependencies, like a
     # Cargo-style build

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -71,10 +71,14 @@ actions:
                 echo "import Distribution.Simple" > Setup.hs
                 echo "main = defaultMain" >> Setup.hs
             fi
+            export GHCV=$(ghc --numeric-version)
             runhaskell Setup configure --prefix=%PREFIX% \
                                        --libdir=%libdir% \
+                                       --libsubdir="\$compiler/\$pkgid" \
                                        --sysconfdir=/etc \
                                        --disable-tests \
+                                       --enable-executable-dynamic \
+                                       --enable-shared \
                                        -O2 \
                                        "$@"
         }
@@ -87,6 +91,8 @@ actions:
         export GHCV=$(ghc --numeric-version)
         runhaskell Setup register --gen-pkg-config=$package-$version.conf
         install -D -m 00644 $package-$version.conf $installdir%libdir%/ghc-$GHCV/package.conf.d/$package-$version.conf
+    - haskell_check: |
+        runhaskell Setup test %JOBS%
     # Configures a Cabal project that requires online dependencies, like a
     # Cargo-style build
     - cabal_configure: |
@@ -95,6 +101,7 @@ actions:
             cabal update
             cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-H128m %JOBS%" "$@"
             %haskell_configure --disable-executable-dynamic \
+                               --disable-shared \
                                --package-db=$HOME/.cabal/store/ghc-$GHCV/package.db \
                                "$@"
         }

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -90,7 +90,7 @@ actions:
         haskell_configure
     - haskell_build: &haskell_build |
         runhaskell Setup build %JOBS%
-    - haskell_install: &haskelll_install |
+    - haskell_install: &haskell_install |
         runhaskell Setup copy --destdir=$installdir
     - haskell_register: &haskell_register |
         export GHCV=$(ghc --numeric-version)

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -64,7 +64,7 @@ actions:
         }
         apply_patches
     # Make life easier with Haskell/Cabal
-    - haskell_configure: |
+    - haskell_configure: &haskell_configure |
         function haskell_configure() {
             if [[ ! -e Setup.hs ]] && [[ ! -e Setup.lhs ]]; then
                 echo "No Setup.hs file found, creating our own..."
@@ -88,11 +88,11 @@ actions:
                                        "$@"
         }
         haskell_configure
-    - haskell_build: |
+    - haskell_build: &haskell_build |
         runhaskell Setup build %JOBS%
-    - haskell_install: |
+    - haskell_install: &haskelll_install |
         runhaskell Setup copy --destdir=$installdir
-    - haskell_register: |
+    - haskell_register: &haskell_register |
         export GHCV=$(ghc --numeric-version)
         runhaskell Setup register --gen-pkg-config=$package-$version.conf
         install -D -m 00644 $package-$version.conf $installdir%libdir%/ghc-$GHCV/package.conf.d/$package-$version.conf
@@ -106,15 +106,14 @@ actions:
             cabal update
             cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-H128m %JOBS%" "$@"
             %haskell_configure --disable-executable-dynamic \
-                               --disable-shared \
                                --package-db=$HOME/.cabal/store/ghc-$GHCV/package.db \
                                "$@"
         }
         cabal_configure
     # # TODO: remove after all Haskell packages have been migrated
-    # - cabal_build: *haskell_build
-    # - cabal_install: *haskell_install
-    # - cabal_register: *haskell_register
+    - cabal_build: *haskell_build
+    - cabal_install: *haskell_install
+    - cabal_register: *haskell_register
     # Make life easier with Perl
     - perl_setup: |
         function perl_setup() {

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -76,7 +76,7 @@ actions:
                                        --libdir=%libdir% \
                                        --libsubdir="\$compiler/\$pkgid" \
                                        --libexecdir="%libdir%/\$compiler/\$pkgid" \
-                                       --dynlibdir=%libdir% \ 
+                                       --dynlibdir=%libdir% \
                                        --datadir=/usr/share \
                                        --datasubdir=%PKGNAME% \
                                        --docdir="/usr/share/doc/%PKGNAME%" \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -63,27 +63,53 @@ actions:
             done < $srs
         }
         apply_patches
-    # Make life easier with Haskell
-    - cabal_configure: |
+    # Make life easier with Haskell/Cabal
+    # And yes, %JOBS% needs to be specified two times.
+    - haskell_configure: |
+        function haskell_configure() {
+            if [[ ! -e Setup.hs ]] && [[ ! -e Setup.lhs ]]; then
+                echo "No Setup.hs file found, creating our own..."
+                echo "import Distribution.Simple" > Setup.hs
+                echo "main = defaultMain" >> Setup.hs
+            fi
+            runhaskell Setup.*hs configure --prefix=%PREFIX% \
+                                           --libdir=%libdir% \
+                                           --libsubdir="\$compiler/\$pkgid" \
+                                           --sysconfdir=/etc \
+                                           --disable-tests \
+                                           --disable-executable-static \
+                                           --enable-executable-dynamic \
+                                           --enable-shared \
+                                           --disable-static \
+                                           -O2 \
+                                           --ghc-options="-fPIC -H128m %JOBS%" \
+                                           "$@"
+        }
+        haskell_configure
+    - haskell_build: |
+        runhaskell Setup.*hs build %JOBS%
+    - haskell_install: |
+        runhaskell Setup.*hs copy --destdir=$installdir
+    - haskell_register: |
         export GHCV=$(ghc --numeric-version)
-        mkdir -p ~/.ghc/%ARCH%-linux-$GHCV/package.conf.d
-        cp /usr/lib%LIBSUFFIX%/ghc-$GHCV/package.conf.d/* ~/.ghc/%ARCH%-linux-$GHCV/package.conf.d
-        ghc-pkg recache --user
-        cabal configure --prefix=%PREFIX% \
-                        --libdir=%libdir% \
-                        --libsubdir="\$compiler/\$pkgid" \
-                        --sysconfdir=/etc \
-                        --enable-executable-dynamic \
-                        --enable-shared \
-                        --ghc-options="-O2 -fPIC"
-    - cabal_build: |
-        cabal build %JOBS%
-    - cabal_install: |
-        cabal copy --destdir=$installdir
-    - cabal_register: |
-        export GHCV=$(ghc --numeric-version)
-        cabal register --gen-pkg-config=$package-$version.conf
+        runhaskell Setup.*hs register --gen-pkg-config=$package-$version.conf
         install -D -m 00644 $package-$version.conf $installdir%libdir%/ghc-$GHCV/package.conf.d/$package-$version.conf
+    # Configures a Cabal project that requires online dependencies, like a
+    # Cargo-style build
+    - cabal_configure: |
+        function cabal_configure() {
+            export GHCV=$(ghc --numeric-version)
+            cabal update
+            cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-fPIC -H128m %JOBS%" "$@"
+            %haskell_configure --disable-executable-dynamic \
+                               --package-db=$HOME/.cabal/store/ghc-$GHCV/package.db \
+                               "$@"
+        }
+        cabal_configure
+    # TODO: remove after all Haskell packages have been migrated
+    - cabal_build: *haskell_build
+    - cabal_install: *haskell_install
+    - cabal_register: *haskell_register
     # Make life easier with Perl
     - perl_setup: |
         function perl_setup() {

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -74,8 +74,11 @@ actions:
             export GHCV=$(ghc --numeric-version)
             runhaskell Setup configure --prefix=%PREFIX% \
                                        --libdir=%libdir% \
-                                       --libsubdir="\$compiler/\$pkgid" \
+                                       --libsubdir='$compiler/$pkgid' \
                                        --sysconfdir=/etc \
+                                       --datadir=/usr/share \
+                                       --datasubdir='$pkg' \
+                                       --docdir='/usr/share/doc/$pkg' \
                                        --disable-tests \
                                        --enable-executable-dynamic \
                                        --enable-shared \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -74,12 +74,12 @@ actions:
             export GHCV=$(ghc --numeric-version)
             runhaskell Setup configure --prefix=%PREFIX% \
                                        --libdir=%libdir% \
-                                       --libsubdir='$compiler/$pkgid' \
-                                       --libexecdir='%libdir%/$compiler/$pkgid' \
+                                       --libsubdir="\$compiler/\$pkgid" \
+                                       --libexecdir="%libdir%/\$compiler/\$pkgid" \
                                        --dynlibdir=%libdir% \ 
                                        --datadir=/usr/share \
                                        --datasubdir=%PKGNAME% \
-                                       --docdir='/usr/share/doc/%PKGNAME%' \
+                                       --docdir="/usr/share/doc/%PKGNAME%" \
                                        --sysconfdir=/etc \
                                        --disable-tests \
                                        --enable-executable-dynamic \

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -103,10 +103,10 @@ actions:
                                "$@"
         }
         cabal_configure
-    # TODO: remove after all Haskell packages have been migrated
-    - cabal_build: *haskell_build
-    - cabal_install: *haskell_install
-    - cabal_register: *haskell_register
+    # # TODO: remove after all Haskell packages have been migrated
+    # - cabal_build: *haskell_build
+    # - cabal_install: *haskell_install
+    # - cabal_register: *haskell_register
     # Make life easier with Perl
     - perl_setup: |
         function perl_setup() {


### PR DESCRIPTION
Documented by Cabal [here](https://cabal.readthedocs.io/en/3.10/setup-commands.html). The necessary libraries (`Distribution.Simple`) are built with GHC, so this can remove the cyclic dependency where every Haskell package depends on `cabal-install`.

Depends on getsolus/usysconf#12.