### PR TITLE
ypkg2: Only enable fakeroot during the install & check steps

### DIFF
--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "PACKAGE\.YML" "5" "June 2022" ""
+.TH "PACKAGE\.YML" "5" "July 2023" ""
 .SH "NAME"
 \fBpackage\.yml\fR \- Solus package build format
 .SH "SYNOPSIS"
@@ -187,6 +187,10 @@ If in doubt, omit this option where possible\.
 \fBmancompress\fR [boolean]
 .IP
 By default, this key is disabled\. Enables compression of man/info pages using gzip at the maximum compression level, to decrease the installed size of the package on disk\. Disabled by default as it generally increases the size of eopkg file(s) due to xz having a hard time compressing pre\-compressed gzip files\. Only enable when it significantly reduces the installed size of a package on disk without sacrificing eopkg size too much\.
+.IP "\[ci]" 4
+\fBfatfakeroot\fR [boolean]
+.IP
+By default, this key is disabled\. By default, fakeroot is only enabled for the "install" and "check" steps due to it\'s massive performance overhead\. Enabling, this key will enable fakeroot for all build stages\. You may want to enable this if you are experiencing strange "Permission Denied" errors in the "build" stage, or when rebuilding a reverse dependency against a package\.
 .IP "\[ci]" 4
 \fBdebug\fR [boolean]
 .IP

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -400,6 +400,15 @@ additional functionality.</p>
   size of a package on disk without sacrificing eopkg size too much.</p>
   </li>
   <li>
+    <p><code>fatfakeroot</code> [boolean]</p>
+
+    <p>By default, this key is disabled. By default, fakeroot is only enabled for the
+  "install" and "check" steps due to it's massive performance overhead. Enabling,
+  this key will enable fakeroot for all build stages. You may want to enable this
+  if you are experiencing strange "Permission Denied" errors in the "build" stage,
+  or when rebuilding a reverse dependency against a package.</p>
+  </li>
+  <li>
     <p><code>debug</code> [boolean]</p>
 
     <p>By default, this key is enabled, and as a result <code>ypkg-build(1)</code> will
@@ -657,7 +666,7 @@ builddeps:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>June 2022</li>
+    <li class='tc'>July 2023</li>
     <li class='tr'>package.yml(5)</li>
   </ol>
 

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -292,6 +292,14 @@ additional functionality.
     gzip files. Only enable when it significantly reduces the installed
     size of a package on disk without sacrificing eopkg size too much.
 
+* `fatfakeroot` [boolean]
+
+    By default, this key is disabled. By default, fakeroot is only enabled for the
+    "install" and "check" steps due to it's massive performance overhead. Enabling,
+    this key will enable fakeroot for all build stages. You may want to enable this
+    if you are experiencing strange "Permission Denied" errors in the "build" stage,
+    or when rebuilding a reverse dependency against a package.
+
 * `debug` [boolean]
 
     By default, this key is enabled, and as a result `ypkg-build(1)` will

--- a/man/ypkg-build.1
+++ b/man/ypkg-build.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-BUILD" "1" "March 2022" ""
+.TH "YPKG\-BUILD" "1" "July 2023" ""
 .SH "NAME"
 \fBypkg\-build\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg-build.1.html
+++ b/man/ypkg-build.1.html
@@ -163,7 +163,7 @@ and result in an identical package, byte for byte.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2022</li>
+    <li class='tc'>July 2023</li>
     <li class='tr'>ypkg-build(1)</li>
   </ol>
 

--- a/man/ypkg-install-deps.1
+++ b/man/ypkg-install-deps.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-INSTALL\-DEPS" "1" "March 2022" ""
+.TH "YPKG\-INSTALL\-DEPS" "1" "July 2023" ""
 .SH "NAME"
 \fBypkg\-install\-deps\fR \- Install build dependencies
 .SH "SYNOPSIS"

--- a/man/ypkg-install-deps.1.html
+++ b/man/ypkg-install-deps.1.html
@@ -153,7 +153,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2022</li>
+    <li class='tc'>July 2023</li>
     <li class='tr'>ypkg-install-deps(1)</li>
   </ol>
 

--- a/man/ypkg.1
+++ b/man/ypkg.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG" "1" "March 2022" ""
+.TH "YPKG" "1" "July 2023" ""
 .SH "NAME"
 \fBypkg\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg.1.html
+++ b/man/ypkg.1.html
@@ -154,7 +154,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2022</li>
+    <li class='tc'>July 2023</li>
     <li class='tr'>ypkg(1)</li>
   </ol>
 

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -148,10 +148,9 @@ def execute_step(context, step, step_n, work_dir):
     if context.avx2 and step_n == "install":
         endScript = "%avx2_lib_shift"
 
-    # We only want fakeroot for the install and check steps due
-    # to massive performance overhead.
-    # This is a quick n' dirty way of achieving that
-    if not step_n in ["install", "check"]:
+    # Generally, we only want fakeroot for the install and check steps due
+    # to the massive performance overhead unless fatfakeroot is requested.
+    if not step_n in ["install", "check"] and not context.spec.pkg_fatfakeroot:
         script.define_unexport("LD_PRELOAD")
 
     exports = script.emit_exports()

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -148,6 +148,12 @@ def execute_step(context, step, step_n, work_dir):
     if context.avx2 and step_n == "install":
         endScript = "%avx2_lib_shift"
 
+    # We only want fakeroot for the install and check steps due
+    # to massive performance overhead.
+    # This is a quick n' dirty way of achieving that
+    if not step_n in ["install", "check"]:
+        script.define_unexport("LD_PRELOAD")
+
     exports = script.emit_exports()
 
     # Run via bash with enable and error

--- a/ypkg2/ypkgspec.py
+++ b/ypkg2/ypkgspec.py
@@ -92,6 +92,7 @@ class YpkgSpec:
     pkg_strip = True
     pkg_lastrip = True
     pkg_mancompress = False
+    pkg_fatfakeroot = False
     pkg_ccache = True
     pkg_emul32 = False
     pkg_avx2 = False
@@ -207,6 +208,7 @@ class YpkgSpec:
             ("strip", bool),
             ("lastrip", bool),
             ("mancompress", bool),
+            ("fatfakeroot", bool),
             ("ccache", bool),
             ("emul32", bool),
             ("networking", bool),


### PR DESCRIPTION
This will only allow $installdir to be used during install and check steps. (Though, packagers should only be using it during install.)
    
This is extremely desirable due to the extreme overhead of fakeroot. Especially when ccache is enabled but there are no cache hits for a build.