### PR TITLE
main: Use ConfigParser instead of ConfigObj to parse packager config

### DIFF
--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -30,12 +30,12 @@ import ypkg2
 
 import sys
 import argparse
+import ConfigParser
 import os
 import shutil
 import tempfile
 import time
 import subprocess
-from configobj import ConfigObj
 
 
 def show_version():
@@ -205,9 +205,10 @@ def build_package(filename, outputDir):
         if not os.path.exists(fpath):
             continue
         try:
-            c = ConfigObj(fpath)
-            pname = c["Packager"]["Name"]
-            pemail = c["Packager"]["Email"]
+            c = ConfigParser.ConfigParser()
+            c.readfp(open(fpath))
+            pname = c.get("Packager", "Name")
+            pemail = c.get("Packager", "Email")
 
             packager_name = pname
             packager_email = pemail


### PR DESCRIPTION
ConfigParser is part of the stdlib. Since ypkg is still python2, that means we can drop python2 support for configobj and six.