### PR TITLE
Adjust from legacy to current glibc hwcaps

### DIFF
--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "PACKAGE\.YML" "5" "July 2023" ""
+.TH "PACKAGE\.YML" "5" "August 2023" ""
 .SH "NAME"
 \fBpackage\.yml\fR \- Solus package build format
 .SH "SYNOPSIS"
@@ -200,9 +200,11 @@ In the majority of cases, this is the desired behaviour in full build environmen
 .IP "\[ci]" 4
 \fBavx2\fR [boolean]
 .IP
-If set, the package will be rebuilt again specifically to enable libraries to be optimised to use \fBAdvanced Vector Extensions\fR\.
+If set, the package will be rebuilt again with the \fBx86\-64\-v3\fR microarchitecture to enable libraries to be optimised to use newer hardware instructions such as \fBAdvanced Vector Extensions\fR\. From baseline (\fBx86\-64\fR) to v3 (\fBx86\-64\-v3\fR) it allows the compiler to use additional instructions such as, but not limited to; SSE4\.2, SSSE3, POPCNT, CMPXCHG16B, MOVBE and AVX2\.
 .IP
-The build will be configured with a library directory suffix of \fBhaswell\fR, i\.e\. \fB/usr/lib64/haswell\fR or \fB/usr/lib32/haswell\fR\. These libraries will be automatically loaded on the Solus installation if the hardware support is present\.
+The build will be configured to make use of the glibc HWCaps (hardware capabilities) feature, by placing the libraries into the library directory suffix of \fBglibc\-hwcaps/x86\-64\-v3\fR i\.e\. \fB/usr/lib64/glibc\-hwcaps/x86\-64\-v3\fR\.
+.IP
+These libraries will be automatically loaded on the Solus installation if the hardware supports the \fBx86\-64\-v3\fR microarchitecture\.
 .IP "\[ci]" 4
 \fBoptimize\fR [list]
 .IP
@@ -213,6 +215,8 @@ Valid keys are restricted to:
 \fBsize\fR: Optimize the package build solely for size\.
 .IP "\[ci]" 4
 \fBno\-bind\-now\fR: Configure the package to disable certain flags, where RELRO is unsupported\.
+.IP "\[ci]" 4
+\fBno\-frame\-pointer\fR: Disable \fB\-fno\-omit\-frame\-pointer\fR and \fB\-mno\-omit\-leaf\-frame\-pointer\fR compiler flags
 .IP "\[ci]" 4
 \fBno\-symbolic\fR: Disable \fB\-Wl,\-Bsymbolic\-functions\fR linker flag
 .IP "\[ci]" 4

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -422,13 +422,17 @@ additional functionality.</p>
   <li>
     <p><code>avx2</code> [boolean]</p>
 
-    <p>If set, the package will be rebuilt again specifically to enable libraries
-  to be optimised to use <strong>Advanced Vector Extensions</strong>.</p>
+    <p>If set, the package will be rebuilt again with the <code>x86-64-v3</code> microarchitecture to enable
+  libraries to be optimised to use newer hardware instructions such as <strong>Advanced Vector Extensions</strong>.
+  From baseline (<code>x86-64</code>) to v3 (<code>x86-64-v3</code>) it allows the compiler to use additional instructions such as,
+  but not limited to; SSE4.2, SSSE3, POPCNT, CMPXCHG16B, MOVBE and AVX2.</p>
 
-    <p>The build will be configured with a library directory suffix of <code>haswell</code>,
-  i.e. <code>/usr/lib64/haswell</code> or <code>/usr/lib32/haswell</code>. These libraries will be
-  automatically loaded on the Solus installation if the hardware support
-  is present.</p>
+    <p>The build will be configured to make use of the glibc HWCaps (hardware capabilities) feature, by
+  placing the libraries into the library directory suffix of <code>glibc-hwcaps/x86-64-v3</code>
+  i.e. <code>/usr/lib64/glibc-hwcaps/x86-64-v3</code>.</p>
+
+    <p>These libraries will be automatically loaded on the Solus installation if the hardware supports the <code>x86-64-v3</code>
+  microarchitecture.</p>
   </li>
   <li>
     <p><code>optimize</code> [list]</p>
@@ -668,7 +672,7 @@ builddeps:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2023</li>
+    <li class='tc'>August 2023</li>
     <li class='tr'>package.yml(5)</li>
   </ol>
 

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -312,13 +312,17 @@ additional functionality.
 
 * `avx2` [boolean]
 
-    If set, the package will be rebuilt again specifically to enable libraries
-    to be optimised to use **Advanced Vector Extensions**.
+    If set, the package will be rebuilt again with the `x86-64-v3` microarchitecture to enable
+    libraries to be optimised to use newer hardware instructions such as **Advanced Vector Extensions**.
+    From baseline (`x86-64`) to v3 (`x86-64-v3`) it allows the compiler to use additional instructions such as,
+    but not limited to; SSE4.2, SSSE3, POPCNT, CMPXCHG16B, MOVBE and AVX2.
 
-    The build will be configured with a library directory suffix of `haswell`,
-    i.e. `/usr/lib64/haswell` or `/usr/lib32/haswell`. These libraries will be
-    automatically loaded on the Solus installation if the hardware support
-    is present.
+    The build will be configured to make use of the Glibc HWCaps (hardware capabilities) feature, by
+    placing the libraries into the library directory suffix of `glibc-hwcaps/x86-64-v3`
+    i.e. `/usr/lib64/glibc-hwcaps/x86-64-v3`.
+
+    These libraries will be automatically loaded on the Solus installation if the hardware supports the `x86-64-v3`
+    microarchitecture.
 
 * `optimize` [list]
 

--- a/man/ypkg-build.1
+++ b/man/ypkg-build.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-BUILD" "1" "July 2023" ""
+.TH "YPKG\-BUILD" "1" "August 2023" ""
 .SH "NAME"
 \fBypkg\-build\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg-build.1.html
+++ b/man/ypkg-build.1.html
@@ -163,7 +163,7 @@ and result in an identical package, byte for byte.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2023</li>
+    <li class='tc'>August 2023</li>
     <li class='tr'>ypkg-build(1)</li>
   </ol>
 

--- a/man/ypkg-install-deps.1
+++ b/man/ypkg-install-deps.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-INSTALL\-DEPS" "1" "July 2023" ""
+.TH "YPKG\-INSTALL\-DEPS" "1" "August 2023" ""
 .SH "NAME"
 \fBypkg\-install\-deps\fR \- Install build dependencies
 .SH "SYNOPSIS"

--- a/man/ypkg-install-deps.1.html
+++ b/man/ypkg-install-deps.1.html
@@ -153,7 +153,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2023</li>
+    <li class='tc'>August 2023</li>
     <li class='tr'>ypkg-install-deps(1)</li>
   </ol>
 

--- a/man/ypkg.1
+++ b/man/ypkg.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG" "1" "July 2023" ""
+.TH "YPKG" "1" "August 2023" ""
 .SH "NAME"
 \fBypkg\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg.1.html
+++ b/man/ypkg.1.html
@@ -154,7 +154,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2023</li>
+    <li class='tc'>August 2023</li>
     <li class='tr'>ypkg(1)</li>
   </ol>
 

--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -422,8 +422,7 @@ class PackageExaminer:
         if pretty.startswith("/emul32"):
             return True
         # Nuke AVX2 dir .a files with no remorse
-        if (pretty.startswith("/usr/lib64/glibc-hwcaps/x86-64-v3/") or
-                pretty.startswith("/usr/lib32/glibc-hwcaps/x86-64-v3/")):
+        if (pretty.startswith("/usr/lib64/glibc-hwcaps/x86-64-v3/"):
             if ".so" not in pretty:
                 return True
             # Don't want .so links, they're useless.

--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -422,8 +422,8 @@ class PackageExaminer:
         if pretty.startswith("/emul32"):
             return True
         # Nuke AVX2 dir .a files with no remorse
-        if (pretty.startswith("/usr/lib64/haswell/") or
-                pretty.startswith("/usr/lib32/haswell/")):
+        if (pretty.startswith("/usr/lib64/glibc-hwcaps/x86-64-v3/") or
+                pretty.startswith("/usr/lib32/glibc-hwcaps/x86-64-v3/")):
             if ".so" not in pretty:
                 return True
             # Don't want .so links, they're useless.

--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -288,12 +288,7 @@ def build_package(filename, outputDir):
 
     possible_sets = []
     # Emul32 is *always* first
-    # AVX2 emul32 comes first too so "normal" emul32 can override it
     if spec.pkg_emul32:
-        if spec.pkg_avx2:
-            # Emul32, avx2 build
-            possible_sets.append((True, True))
-        # Normal, no-avx2, emul32 build
         possible_sets.append((True, False))
 
     # Build AVX2 before native, but after emul32

--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -153,12 +153,12 @@ class PackageGenerator:
         self.add_pattern("/bin", "main")
         self.add_pattern("/usr/share/info", "main")
         self.add_pattern("/usr/lib64/lib*.so.*", "main")
-        self.add_pattern("/usr/lib64/haswell/*.so*", "main")
+        self.add_pattern("/usr/lib64/glibc-hwcaps/x86-64-v3/*.so*", "main")
         self.add_pattern("/usr/lib/lib*.so.*", "main")
         self.add_pattern("/usr/lib32/", "32bit")
         self.add_pattern("/usr/lib32/lib*.so.*", "32bit",
                          priority=PRIORITY_DEFAULT+1)
-        self.add_pattern("/usr/lib32/haswell/*.so*", "32bit",
+        self.add_pattern("/usr/lib32/glibc-hwcaps/x86-64-v3/*.so*", "32bit",
                          priority=PRIORITY_DEFAULT+1)
 
         self.add_pattern("/usr/share/locale", "main")

--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -158,8 +158,6 @@ class PackageGenerator:
         self.add_pattern("/usr/lib32/", "32bit")
         self.add_pattern("/usr/lib32/lib*.so.*", "32bit",
                          priority=PRIORITY_DEFAULT+1)
-        self.add_pattern("/usr/lib32/glibc-hwcaps/x86-64-v3/*.so*", "32bit",
-                         priority=PRIORITY_DEFAULT+1)
 
         self.add_pattern("/usr/share/locale", "main")
         self.add_pattern("/usr/share/doc", "main")

--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -332,9 +332,9 @@ actions:
         fi
     - avx2_lib_shift: |
         if [ -d "%installroot%/%libdir%" ]; then
-          install -dm00755 $PKG_BUILD_DIR/haswell
-          mv %installroot%/%libdir%/* $PKG_BUILD_DIR/haswell
-          mv $PKG_BUILD_DIR/haswell %installroot%/%libdir%/
+          install -dm00755 $PKG_BUILD_DIR/glibc-hwcaps/x86-64-v3
+          mv %installroot%/%libdir%/* $PKG_BUILD_DIR/glibc-hwcaps/x86-64-v3
+          mv $PKG_BUILD_DIR/glibc-hwcaps %installroot%/%libdir%/
         fi
     - python3_avx2_lib_shift: |
         find %installroot%/usr/lib/python%python3_version%/ -name '*.so' -exec sh -c 'mv "$0" "${0%.so}.so.avx2"' {} \;

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -87,7 +87,7 @@ NO_REORDER_BLOCKS_PARTITIONS = "-fno-reorder-blocks-and-partition"
 POLLY = "-mllvm -polly -mllvm -polly-vectorizer=stripmine"
 
 # AVX2
-AVX2_ARCH = "haswell"
+AVX2_ARCH = "x86-64-v3"
 AVX2_TUNE = "haswell"
 AVX2_FLAGS = "-mprefer-vector-width=128"
 


### PR DESCRIPTION
- Build with march=x86-64-v3 instead of haswell
- Move libs from /usr/lib64/haswell to /usr/lib64/glibc-hwcaps/x86-64-v3
- Drop support for emul32 haswell libs
- Update documentation