### PR TITLE
Add checkdeps field to package.yml

### DIFF
--- a/man/package.yml.5
+++ b/man/package.yml.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "PACKAGE\.YML" "5" "August 2023" ""
+.TH "PACKAGE\.YML" "5" "October 2023" ""
 .SH "NAME"
 \fBpackage\.yml\fR \- Solus package build format
 .SH "SYNOPSIS"
@@ -93,6 +93,16 @@ These keys are not mandatory to a \fBpackage\.yml\fR file, but may be used to co
 \fBbuilddeps\fR [list]
 .IP
 Specifies the build dependencies required to actually make this package build in an isolated environment (\fBsolbuild(1)\fR)\.
+.IP
+You may use full package names here, though it is preferable to use the \fBpkg\-config(1)\fR names\.
+.IP
+\fBypkg\-build(1)\fR understands pkgconfig dependencies denoted inside either the \fBpkgconfig($name)\fR identifier, or \fBpkgconfig32($name)\fR for emul32 build dependencies\.
+.IP
+It is not required to list any package here that exists in the \fBsystem\.base\fR or \fBsystem\.devel\fR component\.
+.IP "\[ci]" 4
+\fBcheckdeps\fR [list]
+.IP
+Specifies the build and/or run dependencies required to build and/or run the tests of this package in an isolated environment (\fBsolbuild(1)\fR)\.
 .IP
 You may use full package names here, though it is preferable to use the \fBpkg\-config(1)\fR names\.
 .IP
@@ -202,7 +212,7 @@ In the majority of cases, this is the desired behaviour in full build environmen
 .IP
 If set, the package will be rebuilt again with the \fBx86\-64\-v3\fR microarchitecture to enable libraries to be optimised to use newer hardware instructions such as \fBAdvanced Vector Extensions\fR\. From baseline (\fBx86\-64\fR) to v3 (\fBx86\-64\-v3\fR) it allows the compiler to use additional instructions such as, but not limited to; SSE4\.2, SSSE3, POPCNT, CMPXCHG16B, MOVBE and AVX2\.
 .IP
-The build will be configured to make use of the glibc HWCaps (hardware capabilities) feature, by placing the libraries into the library directory suffix of \fBglibc\-hwcaps/x86\-64\-v3\fR i\.e\. \fB/usr/lib64/glibc\-hwcaps/x86\-64\-v3\fR\.
+The build will be configured to make use of the Glibc HWCaps (hardware capabilities) feature, by placing the libraries into the library directory suffix of \fBglibc\-hwcaps/x86\-64\-v3\fR i\.e\. \fB/usr/lib64/glibc\-hwcaps/x86\-64\-v3\fR\.
 .IP
 These libraries will be automatically loaded on the Solus installation if the hardware supports the \fBx86\-64\-v3\fR microarchitecture\.
 .IP "\[ci]" 4

--- a/man/package.yml.5.html
+++ b/man/package.yml.5.html
@@ -239,6 +239,23 @@ additional functionality.</p>
   or <code>system.devel</code> component.</p>
   </li>
   <li>
+    <p><code>checkdeps</code> [list]</p>
+
+    <p>Specifies the build and/or run dependencies required to build and/or run
+  the tests of
+  this package in an isolated environment (<code>solbuild(1)</code>).</p>
+
+    <p>You may use full package names here, though it is preferable to use the
+  <code>pkg-config(1)</code> names.</p>
+
+    <p><code>ypkg-build(1)</code> understands pkgconfig dependencies denoted inside either
+  the <code>pkgconfig($name)</code> identifier, or <code>pkgconfig32($name)</code> for emul32
+  build dependencies.</p>
+
+    <p>It is not required to list any package here that exists in the <code>system.base</code>
+  or <code>system.devel</code> component.</p>
+  </li>
+  <li>
     <p><code>clang</code> [boolean]</p>
 
     <p>Set this key to <code>yes</code> to force building this package with the <code>clang</code>
@@ -427,7 +444,7 @@ additional functionality.</p>
   From baseline (<code>x86-64</code>) to v3 (<code>x86-64-v3</code>) it allows the compiler to use additional instructions such as,
   but not limited to; SSE4.2, SSSE3, POPCNT, CMPXCHG16B, MOVBE and AVX2.</p>
 
-    <p>The build will be configured to make use of the glibc HWCaps (hardware capabilities) feature, by
+    <p>The build will be configured to make use of the Glibc HWCaps (hardware capabilities) feature, by
   placing the libraries into the library directory suffix of <code>glibc-hwcaps/x86-64-v3</code>
   i.e. <code>/usr/lib64/glibc-hwcaps/x86-64-v3</code>.</p>
 
@@ -672,7 +689,7 @@ builddeps:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2023</li>
+    <li class='tc'>October 2023</li>
     <li class='tr'>package.yml(5)</li>
   </ol>
 

--- a/man/package.yml.5.md
+++ b/man/package.yml.5.md
@@ -145,6 +145,22 @@ additional functionality.
     It is not required to list any package here that exists in the `system.base`
     or `system.devel` component.
 
+* `checkdeps` [list]
+
+    Specifies the build and/or run dependencies required to build and/or run
+    the tests of
+    this package in an isolated environment (`solbuild(1)`).
+
+    You may use full package names here, though it is preferable to use the
+    `pkg-config(1)` names.
+
+    `ypkg-build(1)` understands pkgconfig dependencies denoted inside either
+    the `pkgconfig($name)` identifier, or `pkgconfig32($name)` for emul32
+    build dependencies.
+
+    It is not required to list any package here that exists in the `system.base`
+    or `system.devel` component.
+
 * `clang` [boolean]
 
     Set this key to `yes` to force building this package with the `clang`

--- a/man/ypkg-build.1
+++ b/man/ypkg-build.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-BUILD" "1" "August 2023" ""
+.TH "YPKG\-BUILD" "1" "October 2023" ""
 .SH "NAME"
 \fBypkg\-build\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg-build.1.html
+++ b/man/ypkg-build.1.html
@@ -163,7 +163,7 @@ and result in an identical package, byte for byte.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2023</li>
+    <li class='tc'>October 2023</li>
     <li class='tr'>ypkg-build(1)</li>
   </ol>
 

--- a/man/ypkg-install-deps.1
+++ b/man/ypkg-install-deps.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG\-INSTALL\-DEPS" "1" "August 2023" ""
+.TH "YPKG\-INSTALL\-DEPS" "1" "October 2023" ""
 .SH "NAME"
 \fBypkg\-install\-deps\fR \- Install build dependencies
 .SH "SYNOPSIS"

--- a/man/ypkg-install-deps.1.html
+++ b/man/ypkg-install-deps.1.html
@@ -153,7 +153,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2023</li>
+    <li class='tc'>October 2023</li>
     <li class='tr'>ypkg-install-deps(1)</li>
   </ol>
 

--- a/man/ypkg.1
+++ b/man/ypkg.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "YPKG" "1" "August 2023" ""
+.TH "YPKG" "1" "October 2023" ""
 .SH "NAME"
 \fBypkg\fR \- Build Solus ypkg files
 .SH "SYNOPSIS"

--- a/man/ypkg.1.html
+++ b/man/ypkg.1.html
@@ -154,7 +154,7 @@ packages.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2023</li>
+    <li class='tc'>October 2023</li>
     <li class='tr'>ypkg(1)</li>
   </ol>
 

--- a/ypkg-install-deps
+++ b/ypkg-install-deps
@@ -83,6 +83,19 @@ def main():
             if not idb.has_package(dep):
                 ndeps.add(dep)
 
+    if spec.pkg_checkdeps:
+        for dep in spec.pkg_checkdeps:
+            em32 = pkgconfig32_dep.match(dep)
+            if em32:
+                pc32deps.add(em32.group(1))
+                continue
+            em = pkgconfig_dep.match(dep)
+            if em:
+                pcdeps.add(em.group(1))
+                continue
+            if not idb.has_package(dep):
+                ndeps.add(dep)
+
     # Get the global known pkgconfig providers
     pkgConfigs, pkgConfigs32 = pdb.get_pkgconfig_providers()
 

--- a/ypkg2/ypkgspec.py
+++ b/ypkg2/ypkgspec.py
@@ -107,6 +107,7 @@ class YpkgSpec:
 
     # Dependencies
     pkg_builddeps = None
+    pkg_checkdeps = None
 
     mandatory_tokens = None
     optional_tokens = None
@@ -219,6 +220,7 @@ class YpkgSpec:
             ("patterns", MultimapFormat(self, self.add_pattern, "main")),
             ("permanent", OneOrMoreString),
             ("builddeps", OneOrMoreString),
+            ("checkdeps", OneOrMoreString),
             ("rundeps", MultimapFormat(self, self.add_rundep, "main")),
             ("component", MultimapFormat(self, self.add_component, "main")),
             ("conflicts", MultimapFormat(self, self.add_conflict, "main")),


### PR DESCRIPTION
~~Testing still needed.~~ Tested with `python-packaging` and the checkdeps were installed just as builddeps.

Ideally, we can further improve upon this by emitting a warning if a checkdep appears in the final rundeps or duplicates with a builddep, but that can be put into a separate PR.

Once this is merged, I will add relevant documentation to the help center.