### PR TITLE
ybump, yupdate: use max line length of input yaml for output width

### DIFF
--- a/ybump
+++ b/ybump
@@ -26,12 +26,15 @@ if __name__ == "__main__":
         usage()
 
     with open(sys.argv[1]) as fp:
+        lines = fp.readlines()
+        fp.seek(0)
         data = ruamel.yaml.round_trip_load(fp)
     data['release'] += 1
+    maxwidth = len(max(lines, key=len))
     try:
         with open(sys.argv[1], 'w') as fp:
             ruamel.yaml.round_trip_dump(
-                data, fp, indent=4, block_seq_indent=4, width=200,
+                data, fp, indent=4, block_seq_indent=4, width=maxwidth,
                 top_level_colon_align=True, prefix_colon=' ')
     except Exception as e:
         print("Error writing file, may need to reset it.")

--- a/yupdate
+++ b/yupdate
@@ -92,17 +92,20 @@ if __name__ == "__main__":
         source = {url: args.tag_prefix + newversion}
 
     with open(ymlfile, "r") as infile:
+        lines = infile.readlines()
+        infile.seek(0)
         data = ruamel.yaml.round_trip_load(infile)
     data['source'] = sources = []
     sources.append(source)
     if args.nb is not None:
         data['release'] += 1
     data['version'] = newversion
+    maxwidth = len(max(lines, key=len))
 
     try:
         with open(ymlfile, 'w') as fp:
             ruamel.yaml.round_trip_dump(
-                data, fp, indent=4, block_seq_indent=4, width=200,
+                data, fp, indent=4, block_seq_indent=4, width=maxwidth,
                 top_level_colon_align=True, prefix_colon=' ')
     except Exception as e:
         print("Error writing file, may need to reset it.")


### PR DESCRIPTION
This uses the maximum line length to set the output width for the yaml dump in `ybump` and `yupdate`. This avoids having to set a ridiculously large `width` parameter (there is no way to have it accept arbitrary widths).
Without this the scripts mess up formatting for e.g. very long descriptions (or any other line/value longer than 200 characters), which then leads to errors during the package build or other operations.

One could also parse each element of the yaml to find the largest one, but I couldn't quite figure that one out without it getting a bit too complicated

Disadvantage here is that it read the input file twice (once to get the "raw" lines, ones to parse it into a yaml dict). It still happens in the blink of an eye, but it's of course not ideal.

### Example akonadi:

### ybump result before:
![](https://i.imgur.com/PHlIHaO.png)
### ybump result after:
![](https://i.imgur.com/8T9xR2R.png)