### PR TITLE
Remove old, wrong man3 pattern

### DIFF
--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -181,8 +181,6 @@ class PackageGenerator:
         self.add_pattern("/usr/lib64/pkgconfig/*.pc", "devel")
         self.add_pattern("/usr/share/pkgconfig/*.pc", "devel")
         self.add_pattern("/usr/include/", "devel")
-        self.add_pattern("/usr/share/man3/", "devel",
-                         priority=PRIORITY_DEFAULT+1)
         self.add_pattern("/usr/share/man", "main")
         self.add_pattern("/usr/share/aclocal/*.m4", "devel")
         self.add_pattern("/usr/share/aclocal/*.ac", "devel")


### PR DESCRIPTION
This removes the old pattern of `/usr/share/man3/` for the -devel package. This folder isn't used by a single package in the repo, and I assume was meant to be `/usr/share/man/man3` which was added later.
(or the MANPATH was changed at some point?)