### PR TITLE
Add builddeps sorting

### DIFF
--- a/ybump
+++ b/ybump
@@ -30,7 +30,16 @@ if __name__ == "__main__":
         fp.seek(0)
         data = ruamel.yaml.round_trip_load(fp)
     data['release'] += 1
+    builddeps = data.get("builddeps")
     maxwidth = len(max(lines, key=len))
+
+    if builddeps:
+        a = sorted(filter(lambda entry: entry.startswith("pkgconfig("), builddeps))
+        b = sorted(filter(lambda entry: not entry.startswith("pkgconfig("), builddeps))
+        sorted_builddeps = a + b
+        if builddeps != sorted_builddeps:
+            data["builddeps"] = sorted_builddeps
+
     try:
         with open(sys.argv[1], 'w') as fp:
             ruamel.yaml.round_trip_dump(

--- a/yupdate
+++ b/yupdate
@@ -100,7 +100,15 @@ if __name__ == "__main__":
     if args.nb is not None:
         data['release'] += 1
     data['version'] = newversion
+    builddeps = data.get("builddeps")
     maxwidth = len(max(lines, key=len))
+
+    if builddeps:
+        a = sorted(filter(lambda entry: entry.startswith("pkgconfig("), builddeps))
+        b = sorted(filter(lambda entry: not entry.startswith("pkgconfig("), builddeps))
+        sorted_builddeps = a + b
+        if builddeps != sorted_builddeps:
+            data["builddeps"] = sorted_builddeps
 
     try:
         with open(ymlfile, 'w') as fp:


### PR DESCRIPTION
Add automatic sorting of builddeps to ybump and yupdate.

It was discovered that the bugs mentioned on Matrix with regards to package descriptions already occurs with ybump and yupdate anyway so there are no known new issues including this.

I think for workflow reasons this might still make sense to add as a optional go-task check.