### PR TITLE
ypkg2/packages: Fix patterns for 32bit-devel subpackages

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -10,17 +10,29 @@ This will update the ypkg/master and eopkg/python3 branches to their newest comm
 
 ## Manual testing
 
-Start by running `./set_up_ypkg_test_venv.sh` to prepare a stand-alone python3 venv that links to the ../eopkg/pisi module.
+Start by running `./prepare_ypkg_test_venv.sh` to prepare a stand-alone python3 venv that links to the ../eopkg/pisi module.
 
 and follow the instructions it prints out to activate the isolated ypkg_test_venv.
 
-Note that `set_up_ypkg_test_venv.sh` will reset the venv each time it is run.
+Note that `prepare_ypkg_test_venv.sh` will reset the venv each time it is run.
 
-### Run a build
+### Run a simple build
 
 To run a manual package build, run:
 
     time fakeroot ./ypkg-build <path to package.yml under test>
+
+### Run a more complicated build with dependencies
+
+To run a manual package build with dependencies, run:
+
+    ./ypkg-install-deps package.yml
+    time fakeroot ./ypkg-build package.yml
+
+### Remove manually installed dependencies from the step above
+
+Check the eopkg history with `eopkg history`, then find the transaction index of the operation before the operation
+that installed the dependencies and run `eopkg history -t <the transaction>`
 
 ### Exit testing venv
 

--- a/prepare_ypkg_test_venv.sh
+++ b/prepare_ypkg_test_venv.sh
@@ -11,4 +11,4 @@ prepare_venv
 # show useful next steps re. testing
 help
 
-echo "\nNote that the ypkg_test_venv venv is currently active.\n"
+echo -e "\nNote that the ypkg_test_venv venv is currently active.\n"

--- a/ypkg2/packages.py
+++ b/ypkg2/packages.py
@@ -185,9 +185,10 @@ class PackageGenerator:
         self.add_pattern("/usr/share/aclocal/*.m4", "devel")
         self.add_pattern("/usr/share/aclocal/*.ac", "devel")
 
-        self.add_pattern("/usr/lib32/lib*.a", "32bit-devel")
-        self.add_pattern("/usr/lib32/pkgconfig/*.pc", "32bit-devel")
-        self.add_pattern("/usr/lib32/lib*.so.*", "32bit")
+        self.add_pattern("/usr/lib32/lib*.a", "32bit-devel",
+                        priority=PRIORITY_DEFAULT+1)
+        self.add_pattern("/usr/lib32/pkgconfig/*.pc", "32bit-devel",
+                         priority=PRIORITY_DEFAULT+1)
 
         # Debug infos get highest priority. you don't override these guys.
         self.add_pattern("/usr/lib64/debug/", "dbginfo", priority=DBG)


### PR DESCRIPTION
`self.add_pattern("/usr/lib32/", "32bit")` 
defined earlier seems to be overriding these patterns since the py3 port, so increase the priority by one to fixor.

`self.add_pattern("/usr/lib32/lib*.so.*", "32bit"` 
has been removed as it is already defined earlier in the patterns as:
`self.add_pattern("/usr/lib32/lib*.so.*", "32bit",
                         priority=PRIORITY_DEFAULT+1)`

so it looks like this problem has cropped up before.