### PR TITLE
Export xattrs info to files.xml internally in our eopkg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYaml
 lxml
 python-magic
+xattr

--- a/ypkg2/__init__.py
+++ b/ypkg2/__init__.py
@@ -14,6 +14,7 @@
 from .ui import YpkgUI
 
 import re
+import os
 
 
 global console_ui
@@ -27,6 +28,11 @@ def remove_prefix(fpath, prefix):
     if fpath[0] != '/':
         fpath = "/" + fpath
     return fpath
+
+
+def readlink(path):
+    return os.path.normpath(os.readlink(path))
+
 
 pkgconfig32_dep = re.compile("^pkgconfig32\((.*)\)$")
 pkgconfig_dep = re.compile("^pkgconfig\((.*)\)$")

--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -12,7 +12,7 @@
 #
 
 from . import console_ui
-from .metadata import readlink
+from . import readlink
 from . import remove_prefix
 from . import EMUL32PC
 import magic
@@ -21,7 +21,8 @@ import os
 import subprocess
 import shutil
 import multiprocessing
-
+import xattr
+import base64
 global share_ctx
 
 
@@ -32,6 +33,8 @@ v_rel = re.compile(r".*ELF (64|32)\-bit LSB relocatable,")
 shared_lib = re.compile(r".*Shared library: \[(.*)\].*")
 r_path = re.compile(r".*Library rpath: \[(.*)\].*")
 r_soname = re.compile(r".*Library soname: \[(.*)\].*")
+
+global_xattrs = dict()
 
 
 def is_pkgconfig_file(pretty, mgs):
@@ -94,6 +97,8 @@ class FileReport:
     rpaths = None
 
     soname_links = None
+
+    xattrs = None
 
     # Dependent kernel versions
     dep_kernel = None
@@ -328,6 +333,20 @@ def get_debug_path(context, file, magic_string):
     return None
 
 
+def get_xattrs(context, pretty, file):
+    attributes = {}
+
+    try:
+        xt = xattr.xattr(file)
+        if xt:
+            for key in xt:
+                attributes[str(key)] = base64.b64encode(xt[key]).decode("utf-8")
+    except Exception as ex:
+        console_ui.emit_warning("XAttr", "Failed to determine xattr")
+        print(ex)
+    return attributes
+
+
 def examine_file(*args):
     global share_ctx
     package = args[0]
@@ -337,15 +356,14 @@ def examine_file(*args):
 
     context = share_ctx
 
+    xattrs = None
     if v_dyn.match(mgs):
         # Get soname, direct deps and strip
         store_debug(context, pretty, file, mgs)
         strip_file(context, pretty, file, mgs, mode="shared")
-    elif v_bin.match(mgs):
-        # Get direct deps, and strip
-        store_debug(context, pretty, file, mgs)
-        strip_file(context, pretty, file, mgs, mode="executable")
-    elif v_pie.match(mgs):
+    elif v_bin.match(mgs) or v_pie.match(mgs):
+        # Preserve xattr *before* stripping the file.
+        xattrs = get_xattrs(context, pretty, file)
         # Get direct deps, and strip
         store_debug(context, pretty, file, mgs)
         strip_file(context, pretty, file, mgs, mode="executable")
@@ -359,6 +377,8 @@ def examine_file(*args):
         strip_file(context, pretty, file, mgs, mode="ar")
 
     freport = FileReport(pretty, file, mgs)
+    if xattrs and len(xattrs) > 0:
+        freport.xattrs = xattrs
     return freport
 
 
@@ -451,6 +471,7 @@ class PackageExaminer:
         install_dir = context.get_install_dir()
 
         global share_ctx
+        global global_xattrs
 
         share_ctx = context
 
@@ -495,6 +516,11 @@ class PackageExaminer:
         pool.join()
 
         infos = [x.get() for x in results]
+        for info in infos:
+            if not info.xattrs:
+                continue
+            global_xattrs[info.pretty] = info.xattrs
+
 
         for r in removed:
             package.remove_file(r)

--- a/ypkg2/metadata.py
+++ b/ypkg2/metadata.py
@@ -11,7 +11,8 @@
 #  (at your option) any later version.
 
 from . import console_ui, pkgconfig_dep, pkgconfig32_dep
-from . import packager_name, packager_email
+from . import packager_name, packager_email, readlink
+from . import examine
 
 import os
 import pisi.util
@@ -27,6 +28,8 @@ from datetime import timedelta
 import datetime
 import calendar
 import sys
+import xattr
+import base64
 
 
 FileTypes = OrderedDict([
@@ -107,10 +110,6 @@ def get_file_type(t):
     return "data"
 
 
-def readlink(path):
-    return os.path.normpath(os.readlink(path))
-
-
 def create_files_xml(context, package):
     """ Create an XML representation of our files """
     files = pisi.files.Files()
@@ -149,6 +148,17 @@ def create_files_xml(context, package):
                                         hash=hash, uid=str(st.st_uid),
                                         gid=str(st.st_gid),
                                         mode=str(oct(stat.S_IMODE(st.st_mode))).replace("0o", "0"))
+
+        if "/" + path in examine.global_xattrs:
+            info = examine.global_xattrs["/" + path]
+            for attr in info:
+                val = info[attr]
+                console_ui.emit_warning("XAttr", "File {} has xattr set: {}".
+                                        format("/" + path, attr))
+                ftmp = pisi.files.ExtendedAttribute(label=attr,
+                                                    value=val)
+                file_info.extendedAttributes.append(ftmp)
+
         files.append(file_info)
 
     fpath = os.path.join(context.get_packaging_dir(), "files.xml")


### PR DESCRIPTION
Brought back another old commit. Depends on getsolus/eopkg#57 (ypkg will exit with an exception if it imports eopkg without that commit). Has the same limitation regarding nuitka as is mentioned in that PR.

Note that this xattr support intentionally only supports executables for now since we basically only care about the `security.capability` attribute for file capabilities.

This was tested by building packages that both do and do not contain file caps, and installing them with py2 eopkg (no patch applied, so it's unaware of the new fields) and with py3 eopkg (with patch applied so it correctly applies the attributes).