### PR TITLE
Build with fat LTO objects by default and strip LTO bytecode from static archives

### DIFF
--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -293,7 +293,7 @@ def strip_file(context, pretty, file, magic_string, mode=None):
     elif mode == "ko":
         flags = "-g --strip-unneeded"
     elif mode == "ar":
-        flags = "--strip-debug"
+        flags = "--strip-debug -p -R .gnu.lto_* -R .gnu.debuglto_* -R .llvm.lto -N __gnu_lto_v1"
         if context.spec.pkg_clang:
             cmd = "{} llvm-objcopy {} \"{}\""
     try:

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -41,10 +41,10 @@ SIZE_FLAGS = "-Os"
 SIZE_FLAGS_CLANG = "-O2"
 
 # Allow optimizing for LTO
-LTO_FLAGS = "-flto=auto"
+LTO_FLAGS = "-flto=auto -ffat-lto-objects"
 
 # Allow optimizing for thin-lto
-THIN_LTO_FLAGS = "-flto=thin"
+THIN_LTO_FLAGS = "-flto=thin -ffat-lto-objects"
 
 # Allow optimizing for ICF all (identical code folding)
 ICF_ALL_FLAGS = "-Wl,--icf=all"


### PR DESCRIPTION
LTO Bytecode is non portable. Let's build everything with fat lto objects then strip the bytecode after the fact.

Note: only clang 18 supports fat lto objects