### PR TITLE
rc.yml: Update bolt optimization flags

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -413,7 +413,20 @@ actions:
     # Apply bolt profile
     - bolt_opt: |
         boptim(){
-            llvm-bolt ${1}.orig -o ${1}.bolt -data=$PKG_BUILD_DIR/BOLT/final/$(basename ${1}).fdata -reorder-blocks=cache+ -reorder-functions=hfsort+ -split-functions=3 -split-all-cold -split-eh -dyno-stats -icf=1 -use-gnu-stack -use-old-text ${2} ${3} ${4}
+            llvm-bolt ${1}.orig -o ${1}.bolt -data=$PKG_BUILD_DIR/BOLT/final/$(basename ${1}).fdata \
+                -update-debug-sections \
+                -deterministic-debuginfo \
+                -reorder-blocks=ext-tsp \
+                -reorder-functions=hfsort+ \
+                -split-functions \
+                -split-all-cold \
+                -split-eh \
+                -dyno-stats \
+                -icf=1 \
+                -use-gnu-stack \
+                -peepholes=all \
+                -frame-opt=hot \
+                -use-old-text ${2} ${3} ${4}
             cp ${1}.bolt ${1}
         }
         boptim


### PR DESCRIPTION
- Keep debug info now dwarf 5 is properly supported
- use non-deprecated options
- enable peephole and frame-opt optimizations