### PR TITLE
yupdate: Only update the first element in list

### DIFF
--- a/yupdate
+++ b/yupdate
@@ -103,8 +103,7 @@ if __name__ == "__main__":
         infile.seek(0)
         yaml = YAML()
         data = yaml.load(infile)
-    data['source'] = sources = []
-    sources.append(source)
+    data['source'][0] = source
     if args.nb is not None:
         data['release'] += 1
     data['version'] = newversion


### PR DESCRIPTION
If additional sources exist don't nuke them. This is the behaviour we want the vast majority of the time.

test case: `yupdate  24.06.0 https://poppler.freedesktop.org/poppler-24.06.0.tar.xz`

before
```diff
diff --git a/packages/p/poppler/package.yml b/packages/p/poppler/package.yml
index 2ef4d4047b..67c08f43af 100644
--- a/packages/p/poppler/package.yml
+++ b/packages/p/poppler/package.yml
@@ -1,9 +1,8 @@
 name       : poppler
-version    : 24.04.0
-release    : 49
+version    : 24.06.0
+release    : 50
 source     :
-    - https://poppler.freedesktop.org/poppler-24.04.0.tar.xz : 1e804ec565acf7126eb2e9bb3b56422ab2039f7e05863a5dfabdd1ffd1bb77a7
-    - git|https://gitlab.freedesktop.org/poppler/test.git : 400f3ff05b2b1c0ae17797a0bd50e75e35c1f1b1
+    - https://poppler.freedesktop.org/poppler-24.06.0.tar.xz : 0cdabd495cada11f6ee9e75c793f80daf46367b66c25a63ee8c26d0f9ec40c76
 homepage   : http://poppler.freedesktop.org/
 license    : GPL-2.0-or-later
 component  :
 ```

now
```diff
diff --git a/packages/p/poppler/package.yml b/packages/p/poppler/package.yml
index 2ef4d4047b..17593b8f42 100644
--- a/packages/p/poppler/package.yml
+++ b/packages/p/poppler/package.yml
@@ -1,8 +1,8 @@
 name       : poppler
-version    : 24.04.0
-release    : 49
+version    : 24.06.0
+release    : 50
 source     :
-    - https://poppler.freedesktop.org/poppler-24.04.0.tar.xz : 1e804ec565acf7126eb2e9bb3b56422ab2039f7e05863a5dfabdd1ffd1bb77a7
+    - https://poppler.freedesktop.org/poppler-24.06.0.tar.xz : 0cdabd495cada11f6ee9e75c793f80daf46367b66c25a63ee8c26d0f9ec40c76
     - git|https://gitlab.freedesktop.org/poppler/test.git : 400f3ff05b2b1c0ae17797a0bd50e75e35c1f1b1
 homepage   : http://poppler.freedesktop.org/
 license    : GPL-2.0-or-later
 ```

Notice how the additional source doesn't get nuked.