### PR TITLE
examine: Fix runpath detection

### DIFF
--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -32,6 +32,7 @@ v_pie = re.compile(r".*ELF (64|32)\-bit LSB pie executable,")
 v_rel = re.compile(r".*ELF (64|32)\-bit LSB relocatable,")
 shared_lib = re.compile(r".*Shared library: \[(.*)\].*")
 r_path = re.compile(r".*Library rpath: \[(.*)\].*")
+run_path = re.compile(r".*Library runpath: \[(.*)\].*")
 r_soname = re.compile(r".*Library soname: \[(.*)\].*")
 
 global_xattrs = dict()
@@ -139,6 +140,14 @@ class FileReport:
                 if self.rpaths is None:
                     self.rpaths = set()
                 self.rpaths.update(r.group(1).split(":"))
+                continue
+
+            # Also check runpath
+            r2 = run_path.match(line)
+            if r2:
+                if self.rpaths is None:
+                    self.rpaths = set()
+                self.rpaths.update(r2.group(1).split(":"))
                 continue
 
             # Match direct needed dependency


### PR DESCRIPTION
Binutils update https://github.com/getsolus/packages/commit/ddf491a97c28416ea78c9b8f06cfd505dfb92cb5#diff-5f5bc0944056a92ed60811fab1f7d27b2d22e52b93ad867505b0169d485336f1R71 added the `--enable-new-dtags` argument which changed ld so that `RUNPATH` was used instead of `RPATH` (this is a beneficial change for reasons I won't go into here). Unfortunately ypkg only checked for `RPATH` which broke automatic dependency detection when using `RPATH`/`RUNPATH`.

Fix this in ypkg by checking the `readelf` output for `RUNPATH` as well.

Note that this will probably also fix a few other packages that had `Fatal: Unknown symbol` errors (which aren't actually fatal BTW).