### PR TITLE
rc.yml: Pass --overwrite-existing to the python installer module

### DIFF
--- a/ypkg2/rc.yml
+++ b/ypkg2/rc.yml
@@ -256,7 +256,7 @@ actions:
     - python3_install: |
         function python3_install() {
             if [[ -f "pyproject.toml" || -f "setup.cfg" ]]; then
-                python3 -m installer --destdir=%installroot% dist/*.whl $*
+                python3 -m installer --destdir=%installroot% dist/*.whl --overwrite-existing $*
             else
                 echo "No pyproject.toml file found, installing setuptools"
                 python3 setup.py install --root="%installroot%" $* || exit


### PR DESCRIPTION
This can be requied in the case of avx2 build for example where we want to overwrite the avx2 built files with the x86_64 built ones after the avx2 files have been moved to the right place.