### PR TITLE
Switch from readfp to read_file

### DIFF
--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -210,7 +210,7 @@ def build_package(filename, outputDir, buildDir=None):
             continue
         try:
             c = configparser.ConfigParser()
-            c.readfp(open(fpath))
+            c.read_file(open(fpath))
             pname = c.get("Packager", "Name")
             pemail = c.get("Packager", "Email")
 


### PR DESCRIPTION
Resolves inability to read packager file:
```
[Config] Error in packager config:
'ConfigParser' object has no attribute 'readfp'
[Config] Using default packager values
```

>configparser.ConfigParser no longer has a readfp method. Use read_file() instead.

https://docs.python.org/3/whatsnew/3.12.html
