### PR TITLE
macros: Add cargo_cbuild and cargo_cinstall macros

### DIFF
--- a/data/macros/actions/cargo.yaml
+++ b/data/macros/actions/cargo.yaml
@@ -3,22 +3,42 @@ actions:
         cargo fetch -v --locked
 
     - cargo_build: |
-        cargo build -v -j "%YJOBS%" --frozen --release \
-            --config profile.release.debug=\"full\" \
-            --config profile.release.split-debuginfo=\"off\" \
-            --config profile.release.strip=\"none\"
+        cargo build %options_cargo_release%
+
+    - cargo_cbuild: |
+        cargo cbuild %options_cargo_cbuild%
 
     - cargo_install: |
         cargo_install(){
             if [ $# -gt 0 ]; then
                 for binary in "$@"; do
-                    install -Dm00755 target/release/"$binary" $installdir/usr/bin/"$binary"
+                    install -Dm00755 %cargo_target_dir%/"$binary" $installdir/usr/bin/"$binary"
                 done
             else
-                install -Dm00755 target/release/"$package" $installdir/usr/bin/"$package"
+                install -Dm00755 %cargo_target_dir%/"$package" $installdir/usr/bin/"$package"
             fi
         }
         cargo_install
 
+    - cargo_cinstall: |
+        cargo cinstall %options_cargo_cbuild% \
+            --destdir=$installdir \
+            --libdir=%libdir%
+
     - cargo_test: |
-        cargo test -v -j "%YJOBS%" --frozen --release --workspace
+        cargo test %options_cargo_release% --workspace
+
+defines:
+    - cargo_profile: "release"
+    - cargo_target_dir: "target/%cargo_profile%/"
+    - options_cargo: |
+        -v -j "%YJOBS%" --frozen
+    - options_cargo_release: |
+        %options_cargo% --release \
+            --config profile.release.debug=\"full\" \
+            --config profile.release.split-debuginfo=\"off\" \
+            --config profile.release.lto=\"off\" \
+            --config profile.release.strip=\"none\"
+    - options_cargo_cbuild: |
+        %options_cargo% --release \
+            --prefix=%PREFIX%


### PR DESCRIPTION
# Description

This adds macros for `%cargo_cbuild` and `%cargo_cinstall`.

While I was in the area, I added some definitions to make the Cargo macros easier to work with, similar to AerynOS's Cargo macros.

Fixes https://github.com/getsolus/ypkg/issues/97

# Test Plan

- Copy `data/macros/actions` to `/usr/share/ypkg/macros/actions`
- Install `cargo-c`, and build the `rav1e` package, after modifying it to use the new macros.