### PR TITLE
bump,update: Stop doing the weird aligning things with colons

### DIFF
--- a/ypkg2/cli/bump.py
+++ b/ypkg2/cli/bump.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAML
 ## to start with `- ?`. Override this limit in ruamel to allow us to continue to mangle the YAML spec in this way.
 ## 32x the limit oughta be enough for anyone, right?
 from ruamel.yaml.emitter import Emitter
+
 Emitter.MAX_SIMPLE_KEY_LENGTH = 4096
 
 
@@ -38,13 +39,11 @@ def main():
         fp.seek(0)
         yaml = YAML()
         data = yaml.load(fp)
-    data['release'] += 1
+    data["release"] += 1
     maxwidth = len(max(lines, key=len))
     try:
-        with open(sys.argv[1], 'w') as fp:
+        with open(sys.argv[1], "w") as fp:
             yaml.indent(mapping=4, sequence=4, offset=4)
-            yaml.top_level_colon_align = True
-            yaml.prefix_colon = ' '
             yaml.width = maxwidth
             yaml.dump(data, fp)
     except Exception as e:

--- a/ypkg2/cli/update.py
+++ b/ypkg2/cli/update.py
@@ -136,8 +136,6 @@ def main():
     try:
         with open(ymlfile, "w") as fp:
             yaml.indent(mapping=4, sequence=4, offset=4)
-            yaml.top_level_colon_align = True
-            yaml.prefix_colon = " "
             yaml.width = maxwidth
             yaml.dump(data, fp)
     except Exception as e:


### PR DESCRIPTION
## Summary

We've always done this thing where the colons in `package.yml` files were aligned; but only the top-level ones. While it arguably looks nicer (I personally disagree), it also makes it really hard to work with other YAML tooling, such as formatters. It also kept us from being able to automatically sort dependencies. Let's do away with it, unlocking us to use more standard tools.

## Test Plan

1. `python -m venv venv`
2. `source venv/activate.fish`
3. `pip install .`
4. `ybump ~/repos/getsolus/solus-packages/packages/n/nano/package.yml`
