### PR TITLE
macros: prepare haskell macros for cabal-install 3.12 update

### DIFF
--- a/data/macros/actions/haskell.yaml
+++ b/data/macros/actions/haskell.yaml
@@ -43,6 +43,7 @@ actions:
     # Cargo-style build
     - cabal_configure: |
         function cabal_configure() {
+            export CABAL_DIR="$HOME/.cabal"
             export GHCV=$(ghc --numeric-version)
             cabal update
             cabal build %JOBS% --only-dependencies --disable-tests -O2 --ghc-options="-H128m %JOBS%" "$@"


### PR DESCRIPTION
## Summary

In [cabal-install 3.12](https://cabal.readthedocs.io/en/3.12/config.html#directories)
default directories for artifact storage has been changed to use XDG
Base structure. And to restore previous behavior so that dependencies
end up in correct place (`$HOME/.cabal/store/ghc-$GHCV/package.db`),
we should explicitly set `CABAL_DIR` to point to `$HOME/.cabal`.

## Test Plan

Successfully built shellcheck against `haskell-cabal-install` 3.12.1.0 (manually packaged).

Before the change in macro it failed like this:

```
+ runhaskell Setup configure --prefix=/usr --libdir=/usr/lib64 '--libsubdir=$compiler/lib/$abi/$pkg-$version' --libexecdir=/usr/lib64/shellcheck '--dynlibdir=/usr/lib64/$compiler/lib/$abi' --datadir=/usr/share --datasubdir=shellcheck --docdir=/usr/share/doc/shellcheck --sysconfdir=/etc --disable-tests --enable-executable-dynamic --enable-shared -O2 --disable-executable-dynamic --package-db=/root/.cabal/store/ghc-9.4.8/package.db --enable-tests
Configuring ShellCheck-0.11.0...
Error: Setup: Encountered missing or private dependencies:
Diff >=0.4.0 && <1.1,
QuickCheck >=2.14.2 && <2.17,
aeson >=1.4.0 && <2.3,
fgl >=5.7.0 && <5.8.1.0 || >=5.8.1.1 && <5.9,
regex-tdfa >=1.2.0 && <1.4
```
