### PR TITLE
macros/misc: Unset the failglob option if not set

### DIFF
--- a/data/macros/actions/misc.yaml
+++ b/data/macros/actions/misc.yaml
@@ -41,7 +41,13 @@ actions:
 
     - install_license: |
         function install_license() {
-            shopt -s failglob
+            failglobEnabled=0
+
+            if [[ ${SHELLOPTS} =~ "failglob" ]]; then
+                failglobEnabled=1
+            else
+                shopt -s failglob
+            fi
 
             license_dir="$installdir/%PREFIX%/share/licenses/$package"
 
@@ -54,6 +60,10 @@ actions:
             for f in "${files[@]}"; do
                 install -Dm00644 "${f}" "${license_dir}/$(basename ${f})"
             done
+
+            if [[ "${failglobEnabled}" -eq 0 ]]; then
+                shopt -u failglob
+            fi
         }
         install_license
 


### PR DESCRIPTION
## Summary

This should make the macro safe to use anywhere in the `install` section of a package, without having to worry about file globs that occur after the macro is used.

## Test Plan

Build `nano` using this macro, see that `failglob` is unset after the macro completes.
