### PR TITLE
macros/python: Remove python2 macros and add pyproject macros

### DIFF
--- a/data/macros/actions/python.yaml
+++ b/data/macros/actions/python.yaml
@@ -1,87 +1,29 @@
 actions:
-    - python_setup: |
-        function python_setup() {
-            if [[ -e $PKG_BUILD_DIR/.workdir ]]; then
-                cd "$(cat $PKG_BUILD_DIR/.workdir)"
-            else
-                echo "$workdir" > $PKG_BUILD_DIR/.workdir
-            fi
+    - pyproject_build: |
+        python3 -m build --wheel --no-isolation
 
-            instdir=`basename "$PWD"`
-            pushd ..
-                cp -a "$instdir" py2build && pushd py2build
-                    python2.7 setup.py build $* || exit
-                popd
-            popd
-        }
-        python_setup
+    - pyproject_install: |
+        python3 -m installer --destdir=%installroot% dist/*.whl --overwrite-existing
 
-    - python_install: |
-        function python_install() {
-            if [[ -e $PKG_BUILD_DIR/.workdir ]]; then
-                cd "$(cat $PKG_BUILD_DIR/.workdir)"
-            else
-                echo "$workdir" > $PKG_BUILD_DIR/.workdir
-            fi
-
-            instdir=`basename "$PWD"`
-            pushd ..
-                if [[ ! -d py2build ]]; then
-                    cp -a "$instdir" py2build
-                fi
-                pushd py2build
-                    python2.7 setup.py install --root="%installroot%" $* || exit
-                popd
-            popd
-        }
-        python_install
-
-    - python_test: |
-        function python_test() {
-            if [[ -d py2build ]]; then
-                cd py2build
-            fi
-
+    - pytest: |
+        function python3_pytest() {
             if [[ -z $PYTHONPATH ]]; then
-                export PYTHONPATH=%installroot%/usr/lib/python%python2_version%/site-packages:"$PWD"
-                if [[ -d build/lib ]]; then
-                    PYTHONPATH+=/build/lib
-                fi
+                export PYTHONPATH=%python3_sitepackages%:"$PWD"
                 local do_unset=true
             fi
 
-            if [[ -z $1 ]]; then
-                python2 setup.py test || exit 1
-            elif [[ $1 =~ .*\.py$ ]] || [[ $1 == \-* ]]; then
-                python2 "$@" || exit 1
-            else
-                "$@" || exit
-            fi
+            python3 -P -m pytest "$@" || exit 1
 
             if [[ $do_unset ]]; then
                 unset PYTHONPATH
             fi
-
-            if [[ -d ../py2build ]]; then
-                cd ..
-            fi
         }
-        python_test
-
-    - python_compile: |
-        function python_compile() {
-            if [ -z "$1" ]; then
-                python2 -m compileall -q $installdir || exit 1
-            else
-                python2 -m compileall -q $* || exit 1
-            fi
-        }
-        python_compile
+        python3_pytest
 
     - python3_setup: |
         function python3_setup() {
             if [[ -f "pyproject.toml" || -f "setup.cfg" ]]; then
-                python3 -m build --wheel --no-isolation $*
+                %pyproject_build $*
             else
                 echo "No pyproject.toml file found, assuming project isn't PEP517 compatibile"
                 python3 setup.py build $* || exit
@@ -92,7 +34,7 @@ actions:
     - python3_install: |
         function python3_install() {
             if [[ -f "pyproject.toml" || -f "setup.cfg" ]]; then
-                python3 -m installer --destdir=%installroot% dist/*.whl --overwrite-existing $*
+                %pyproject_install $*
             else
                 echo "No pyproject.toml file found, installing setuptools"
                 python3 setup.py install --root="%installroot%" $* || exit
@@ -103,7 +45,7 @@ actions:
     - python3_test: |
         function python3_test() {
             if [[ -z $PYTHONPATH ]]; then
-                export PYTHONPATH=%installroot%/usr/lib/python%python3_version%/site-packages:"$PWD"
+                export PYTHONPATH=%python3_sitepackages%:"$PWD"
                 local do_unset=true
             fi
 
@@ -124,7 +66,7 @@ actions:
     - python3_compile: |
         function python3_compile() {
             if [ -z "$1" ]; then
-                python3 -m compileall -q $installdir || exit 1
+                python3 -m compileall -q ${installdir} || exit 1
             else
                 python3 -m compileall -q $* || exit 1
             fi
@@ -132,11 +74,11 @@ actions:
         python3_compile
 
     - python3_avx2_lib_shift: |
-        find %installroot%/usr/lib/python%python3_version%/ -name '*.so' -exec sh -c 'mv "$0" "${0%.so}.so.avx2"' {} \;
+        find ${installdir}/%PREFIX%/lib/python%python3_version%/ -name '*.so' -exec sh -c 'mv "$0" "${0%.so}.so.avx2"' {} \;
 
 defines:
-    - python2_version: |
-        $(python2 --version 2>&1 | sed -r 's|^Python (.*)\..*$|\1|')
-
     - python3_version: |
         $(python3 --version 2>&1 | sed -r 's|^Python (.*)\..*$|\1|')
+
+    - python3_sitepackages: |
+        ${installdir}/%PREFIX%/lib/python%python3_version%/site-packages/


### PR DESCRIPTION
## Summary

Now that Solus no longer supports anything Python 2, we can remove the old Python 2 macros.

This also addresses an old annoyance where our Python macros try to be a do-all that support PEP517 and non-PEP517 in the same invocation. Some software doesn't play nice and ship files indicating both ways, which confuses the macro, and the wrong commands are run. Making the pyproject macros explicit eliminates having to do things like `rm setup.py` or `rm pyproject.toml` during the package build.

Another very common pattern in packages is `%python3_test pytest`. We can shorten that by having just a `%pytest` macro.

Lastly, adding `%python3_sitepackages%` GREATLY shortens lines in package files that currently have to specify the entire path manually.

## Test Plan

Build `reuse` with all of the new macros, and see that the resulting `.eopkg` file contains the correct files in the correct paths.
