### PR TITLE
metadata: Remove old python 2 hack when adding files to archive

### DIFF
--- a/ypkg2/metadata.py
+++ b/ypkg2/metadata.py
@@ -448,9 +448,7 @@ def create_eopkg(context, gene, package, outputDir):
     pkg.add_files_xml(os.path.join(pdir, "files.xml"))
 
     for finfo in files.list:
-        # old eopkg trick to ensure the file names are all valid
         orgname = os.path.join(context.get_install_dir(), finfo.path)
-        orgname = orgname.encode("utf-8").decode("utf-8").encode("latin1")
 
         # if os.path.islink(orgname) and not os.path.isdir(orgname):
         #     t = history_timestamp


### PR DESCRIPTION
## Summary

`add_to_install()` takes a str not bytes

See https://github.com/getsolus/eopkg/pull/310

## Test Plan

Tell us how you tested your changes.