### PR TITLE
Change default multiprocessing start method to "fork"

### DIFF
--- a/ypkg2/main.py
+++ b/ypkg2/main.py
@@ -11,9 +11,20 @@
 #  (at your option) any later version.
 #
 
+import multiprocessing
+import os
 import subprocess
 import sys
-import os
+
+# Set the multiprocessing start method to 'fork' if available.
+# This is to avoid issues with 'forkserver' and 'spawn' which require
+# all objects to be picklable, which is not the case for many
+# objects used in ypkg2/pisi.
+if hasattr(multiprocessing, "set_start_method"):
+    try:
+        multiprocessing.set_start_method("fork", force=True)
+    except RuntimeError:
+        pass
 
 import pisi.specfile
 from pisi.db.filesdb import FilesDB


### PR DESCRIPTION
## Summary

In python 3.14 it was changed to forkserver by default, however, it seems we have issues with unpickablable pisi objects that get brought into the ypkg context (possibly due to os.environ)

Therefore, stick with what works for now.

## Test Plan

The examining phase now works again