### PR TITLE
macros/misc: Port install, tmpfiles, and sysusers macros from AerynOS

### DIFF
--- a/data/macros/actions/misc.yaml
+++ b/data/macros/actions/misc.yaml
@@ -39,6 +39,18 @@ actions:
             echo "No broken symlinks found.";
         fi
 
+    - install_bin: |
+        install -Dm 00755 -t ${installdir}/usr/bin
+
+    - install_dir: |
+        install -dm 00755
+
+    - install_exe: |
+        install -Dm 00755
+
+    - install_file: |
+        install -Dm 00644
+
     - install_license: |
         function install_license() {
             shopt -s failglob
@@ -56,6 +68,20 @@ actions:
             done
         }
         install_license
+
+    - tmpfiles: |
+        create_tmpfiles() {
+            mkdir -p ${installdir}/%libdir%/tmpfiles.d
+            echo "$@" >> ${installdir}/%libdir%/tmpfiles.d/${package}.conf
+        }
+        create_tmpfiles
+
+    - sysusers: |
+        create_sysusers() {
+            mkdir -p ${installdir}/%libdir%/sysusers.d
+            echo "$@" >> ${installdir}/%libdir%/sysusers.d/${package}.conf
+        }
+        create_sysusers
 
 defines:
     # Get LTS kernel version


### PR DESCRIPTION
## Summary

This means less work when sharing parts of recipes between Solus and AerynOS. They're also generally useful and promote consistency in our package recipes (e.g., `install -Dm00644` vs `install -Dm 00644`).

## Test Plan

Install `ypkg` in a `venv`, and build a contrived package that makes use of all of the macros.
