### PR TITLE
data/macros: No longer update-debug-sections in bolt_opt

### DIFF
--- a/data/macros/actions/pgo.yaml
+++ b/data/macros/actions/pgo.yaml
@@ -30,7 +30,6 @@ actions:
     - bolt_opt: |
         boptim(){
             llvm-bolt ${1}.orig -o ${1}.bolt -data=$PKG_BUILD_DIR/BOLT/final/$(basename ${1}).fdata \
-                -update-debug-sections \
                 -reorder-blocks=ext-tsp \
                 -reorder-functions=hfsort+ \
                 -split-functions \


### PR DESCRIPTION
## Summary

bolt doesn't support compressed debug symbols

## Test Plan

bolt'ing clang now succeeds