### PR TITLE
data/macros: Update bolt optimization flags

### DIFF
--- a/data/macros/actions/pgo.yaml
+++ b/data/macros/actions/pgo.yaml
@@ -31,13 +31,12 @@ actions:
         boptim(){
             llvm-bolt ${1}.orig -o ${1}.bolt -data=$PKG_BUILD_DIR/BOLT/final/$(basename ${1}).fdata \
                 -reorder-blocks=ext-tsp \
-                -reorder-functions=hfsort+ \
+                -reorder-functions=cdsort \
                 -split-functions \
                 -split-all-cold \
                 -split-eh \
                 -dyno-stats \
-                -icf=1 \
-                -use-gnu-stack \
+                -icf \
                 -peepholes=all \
                 -frame-opt=hot \
                 -use-old-text ${2} ${3} ${4}


### PR DESCRIPTION
## Summary

Replace deprecated hfsort+ with cdsort

Replace deprecated -icf=1 usage with -icf

Remove -use-gnu-stack, no longer required since binutils 2.44 https://forge.sourceware.org/binutils-gdb/binutils-gdb-mirror/commit/bbc969306f8d5fb6c7b636e25f6f8e278946ef23

## Test Plan

BOLT'ed libLLVM.so no longer shits the bed with when dlopened