### PR TITLE
Disable fat LTO objects by default, detect LTO built .a/.o files

### DIFF
--- a/data/man/man5/package.yml.5
+++ b/data/man/man5/package.yml.5
@@ -458,6 +458,14 @@ avx2 builds
 .IP \(bu 2
 \f[CR]lto\f[R]: Enable Link Time Optimization
 .IP \(bu 2
+\f[CR]fat\-lto\-objects\f[R]: Emit LTO objects that contain both the
+real object code and the LTO bytecode, i.e.\ compile with
+\f[CR]\-ffat\-lto\-objects\f[R].
+Only relevant in combination with \f[CR]lto\f[R]/\f[CR]thin\-lto\f[R];
+it is required for packages that install \f[CR].a\f[R]/\f[CR].o\f[R]
+files, as \f[CR]ypkg\-build(1)\f[R] refuses to package objects that only
+contain LTO bytecode.
+.IP \(bu 2
 \f[CR]icf\-safe\f[R]: Enable \f[CR]\-Wl,\-\-icf=safe\f[R] to utilize the
 safe Identical Code Folding linker optimization.
 .IP \(bu 2

--- a/data/man/man5/package.yml.5.html
+++ b/data/man/man5/package.yml.5.html
@@ -460,6 +460,13 @@ make linker use RUNPATH’s instead of RPATH’s.</li>
 in avx2 builds</li>
 <li><code>thin-lto</code>: Enable Thin Link Time Optimization</li>
 <li><code>lto</code>: Enable Link Time Optimization</li>
+<li><code>fat-lto-objects</code>: Emit LTO objects that contain both the
+real object code and the LTO bytecode, i.e. compile with
+<code>-ffat-lto-objects</code>. Only relevant in combination with
+<code>lto</code>/<code>thin-lto</code>; it is required for packages that
+install <code>.a</code>/<code>.o</code> files, as
+<code>ypkg-build(1)</code> refuses to package objects that only contain
+LTO bytecode.</li>
 <li><code>icf-safe</code>: Enable <code>-Wl,--icf=safe</code> to utilize
 the safe Identical Code Folding linker optimization.</li>
 <li><code>icf-all</code>: Enable <code>-Wl,--icf=all</code> to utilize

--- a/data/man/man5/package.yml.5.md
+++ b/data/man/man5/package.yml.5.md
@@ -343,6 +343,11 @@ additional functionality.
      * `avx256`: Disables `-mprefer-vector-width=128` in avx2 builds
      * `thin-lto`: Enable Thin Link Time Optimization
      * `lto`: Enable Link Time Optimization
+     * `fat-lto-objects`: Emit LTO objects that contain both the real object
+       code and the LTO bytecode, i.e. compile with `-ffat-lto-objects`.
+       Only relevant in combination with `lto`/`thin-lto`; it is required for
+       packages that install `.a`/`.o` files, as `ypkg-build(1)` refuses to
+       package objects that only contain LTO bytecode.
      * `icf-safe`: Enable `-Wl,--icf=safe` to utilize the safe Identical Code Folding linker optimization.
      * `icf-all`: Enable `-Wl,--icf=all` to utilize the Identical Code Folding linker optimization.
      * `function-sections`: Enables `-ffunction-sections` to generate a seperate ELF section for each function. Recommended for icf with gcc.

--- a/data/schema/schema.json
+++ b/data/schema/schema.json
@@ -345,6 +345,7 @@
           "avx256",
           "thin-lto",
           "lto",
+          "fat-lto-objects",
           "icf-safe",
           "icf-all",
           "polly",

--- a/ypkg2/examine.py
+++ b/ypkg2/examine.py
@@ -16,6 +16,7 @@ import magic
 import re
 import os
 import subprocess
+import sys
 import shutil
 import multiprocessing
 import xattr
@@ -34,6 +35,23 @@ shared_lib = re.compile(r".*Shared library: \[(.*)\].*")
 r_path = re.compile(r".*Library rpath: \[(.*)\].*")
 run_path = re.compile(r".*Library runpath: \[(.*)\].*")
 r_soname = re.compile(r".*Library soname: \[(.*)\].*")
+
+# Section names carrying GCC LTO bytecode
+lto_section_name = re.compile(r"^\.(?:gnu\.lto|gnu\.debuglto|llvm\.lto)")
+
+# Raw LLVM bitcode objects
+llvm_bitcode_magic = re.compile(r"^LLVM IR bitcode")
+
+# Parse output of `readelf -S`
+readelf_section = re.compile(
+    r"^\s*\[\s*\d+\]\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+(\S+)\s+\S+(.*)$"
+)
+
+# When run on an archive, readelf prefixes each member with a 'File:' line.
+readelf_member = re.compile(r"^File:\s+(.+)$")
+
+# readelf refuses to dump sections of raw LLVM bitcode members.
+readelf_bitcode = re.compile(r"^readelf: Error: This is a LLVM bitcode file")
 
 global_xattrs = dict()
 
@@ -83,6 +101,182 @@ def is_system_map(file, mgs):
         return False
 
     return True
+
+
+class LtoBytecodeError(Exception):
+    """Raised by examine workers when an installed .a/.o file only contains
+    LTO bytecode without real object code. Such objects were built with
+    LTO but without -ffat-lto-objects and are unusable."""
+
+    def __init__(self, pretty):
+        Exception.__init__(self, pretty)
+        self.pretty = pretty
+
+
+def may_carry_lto_bytecode(file, mgs):
+    """Filter for installed objects that may carry unusable LTO bytecode"""
+    if file.endswith(".ko"):
+        return False
+    if is_static_archive(file, mgs):
+        return True
+    return bool(file.endswith(".o") and v_rel.match(mgs))
+
+
+def parse_readelf_section(line):
+    """Parse a readelf section header line into a (name, type, size, flags)
+    tuple, or None if the line isn't one"""
+    m = readelf_section.match(line)
+    if m is None:
+        return None
+
+    name = m.group(1)
+    sec_type = m.group(2)
+    size = int(m.group(3), 16)
+
+    rest = m.group(4).strip().split()
+    flags = rest[0] if rest and rest[0].isalpha() else ""
+
+    return (name, sec_type, size, flags)
+
+
+def scan_object_lto_bytecode(file):
+    """Scan a standalone ELF relocatable for LTO bytecode without any real
+    code, i.e. an object compiled with LTO but without -ffat-lto-objects.
+
+    Such objects only contain LTO sections alongside empty placeholder
+    sections, and are unusable when linked without the LTO plugin. Returns
+    True when the object is affected, False otherwise.
+    """
+    try:
+        proc = subprocess.Popen(
+            ["readelf", "-S", "-W", file],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+    except OSError as e:
+        console_ui.emit_warning(
+            "LTO", f"Failed to scan object file for LTO bytecode: {file}"
+        )
+        print(e)
+        return False
+
+    has_lto = False
+    has_code = False
+
+    out = proc.stdout
+    if out is None:
+        proc.wait()
+        return False
+
+    try:
+        for line in out:
+            sec = parse_readelf_section(line)
+            if sec is None:
+                continue
+            name, sec_type, size, flags = sec
+            if lto_section_name.match(name):
+                has_lto = True
+            elif sec_type in ("PROGBITS", "NOBITS") and "A" in flags and size > 0:
+                has_code = True
+    except (OSError, ValueError, UnicodeDecodeError) as e:
+        console_ui.emit_warning(
+            "LTO", f"Failed to scan object file for LTO bytecode: {file}"
+        )
+        print(e)
+        return False
+    finally:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        try:
+            proc.wait()
+        except OSError:
+            pass
+
+    return has_lto and not has_code
+
+
+def scan_archive_lto_bytecode(file):
+    """Scan a static archive for members that only contain LTO bytecode
+    without any real code, i.e. objects compiled with LTO but without
+    -ffat-lto-objects.
+
+    Returns the name of the first offending member, or None when the archive
+    only contains usable objects. Members that are raw LLVM bitcode (Clang
+    LTO objects) are reported as well.
+    """
+    try:
+        proc = subprocess.Popen(
+            ["readelf", "-S", "-W", file],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+    except OSError as e:
+        console_ui.emit_warning(
+            "LTO", f"Failed to scan archive for LTO bytecode: {file}"
+        )
+        print(e)
+        return None
+
+    offending = None
+    member = None
+    has_lto = False
+    has_code = False
+
+    def bad_member():
+        return member if has_lto and not has_code else None
+
+    out = proc.stdout
+    if out is None:
+        proc.wait()
+        return None
+
+    try:
+        for line in out:
+            m = readelf_member.match(line)
+            if m:
+                # New member starts, check the previous one
+                offending = bad_member()
+                if offending:
+                    break
+                member = m.group(1).strip()
+                has_lto = False
+                has_code = False
+                continue
+            if readelf_bitcode.match(line):
+                # Raw LLVM bitcode member is LTO bytecode without any code
+                offending = member
+                break
+            sec = parse_readelf_section(line)
+            if sec is None:
+                continue
+            name, sec_type, size, flags = sec
+            if lto_section_name.match(name):
+                has_lto = True
+            elif sec_type in ("PROGBITS", "NOBITS") and "A" in flags and size > 0:
+                has_code = True
+    except (OSError, ValueError, UnicodeDecodeError) as e:
+        console_ui.emit_warning(
+            "LTO", f"Failed to scan archive for LTO bytecode: {file}"
+        )
+        print(e)
+        return None
+    finally:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        try:
+            proc.wait()
+        except OSError:
+            pass
+
+    if offending is None:
+        offending = bad_member()
+    return offending
 
 
 class FileReport:
@@ -304,7 +498,7 @@ def strip_file(context, pretty, file, magic_string, mode=None):
         flags = "--strip-unneeded"
     elif mode == "ko":
         flags = "-g --strip-unneeded"
-    elif mode == "ar":
+    elif mode == "ar" or mode == "object":
         flags = "--strip-debug -p -R .gnu.lto_* -R .gnu.debuglto_* -R .llvm.lto -N __gnu_lto_v1"
         if context.spec.pkg_clang:
             cmd = '{} llvm-objcopy {} "{}"'
@@ -362,6 +556,17 @@ def examine_file(*args):
 
     context = share_ctx
 
+    # Static archives/object files may carry only LTO bytecode which are unusable without
+    # real code. This must run before the strip below, which discards the LTO sections
+    # from .a/.o files.
+    if may_carry_lto_bytecode(file, mgs):
+        if mgs == "current ar archive":
+            offender = scan_archive_lto_bytecode(file)
+        else:
+            offender = scan_object_lto_bytecode(file)
+        if offender:
+            raise LtoBytecodeError(pretty)
+
     xattrs = None
     if v_dyn.match(mgs):
         # Get soname, direct deps and strip
@@ -378,6 +583,8 @@ def examine_file(*args):
         if file.endswith(".ko"):
             store_debug(context, pretty, file, mgs)
             strip_file(context, pretty, file, mgs, mode="ko")
+        elif file.endswith(".o"):
+            strip_file(context, pretty, file, mgs, mode="object")
     elif mgs == "current ar archive":
         # Strip only.
         strip_file(context, pretty, file, mgs, mode="ar")
@@ -485,6 +692,7 @@ class PackageExaminer:
 
         pool = multiprocessing.Pool()
         results = list()
+        lto_offenders = list()
 
         for file in package.emit_files():
             if file[0] == "/":
@@ -512,6 +720,12 @@ class PackageExaminer:
                 removed.add("/" + file)
                 continue
 
+            # Raw LLVM bitcode objects are not ELF relocatables, so they never get
+            # dispatched for examination. Catch them here with a magic check.
+            # The entire file is unsuitable for distribution regardless.
+            if llvm_bitcode_magic.match(mgs) and file.endswith(".o"):
+                lto_offenders.append("/" + file)
+
             if not self.file_is_of_interest("/" + file, fpath, mgs):
                 continue
             # Handle this asynchronously
@@ -524,7 +738,13 @@ class PackageExaminer:
         pool.close()
         pool.join()
 
-        infos = [x.get() for x in results]
+        infos = list()
+        for x in results:
+            try:
+                infos.append(x.get())
+            except LtoBytecodeError as e:
+                lto_offenders.append(e.pretty)
+
         for info in infos:
             if not info.xattrs:
                 continue
@@ -532,6 +752,22 @@ class PackageExaminer:
 
         for r in removed:
             package.remove_file(r)
+
+        if len(lto_offenders) > 0:
+            for pretty in lto_offenders:
+                console_ui.emit_error(
+                    "LTO",
+                    "{} contains LTO bytecode without real object code".format(
+                        pretty
+                    ),
+                )
+            console_ui.emit_error(
+                "LTO",
+                "Installed .a/.o files must contain real compiled code. "
+                "Preferably remove the offending file or rebuild with "
+                "'fat-lto-objects' as part of the 'optimize' key."
+            )
+
         return infos
 
     def examine_packages(self, context, packages):

--- a/ypkg2/ypkgcontext.py
+++ b/ypkg2/ypkgcontext.py
@@ -41,10 +41,13 @@ SIZE_FLAGS = "-Os"
 SIZE_FLAGS_CLANG = "-O2"
 
 # Allow optimizing for LTO
-LTO_FLAGS = "-flto=auto -ffat-lto-objects"
+LTO_FLAGS = "-flto=auto"
 
 # Allow optimizing for thin-lto
-THIN_LTO_FLAGS = "-flto=thin -ffat-lto-objects"
+THIN_LTO_FLAGS = "-flto=thin"
+
+# Emit both real object code and LTO bytecode, opt-in only (see LTO_FLAGS)
+FAT_LTO_FLAGS = "-ffat-lto-objects"
 
 # Allow optimizing for ICF all (identical code folding)
 ICF_ALL_FLAGS = "-Wl,--icf=all"
@@ -150,6 +153,8 @@ class Flags:
                     newflags.extend(SIZE_FLAGS.split(" "))
         elif opt_type == "lto":
             newflags.extend(LTO_FLAGS.split(" "))
+        elif opt_type == "fat-lto-objects":
+            newflags.extend(FAT_LTO_FLAGS.split(" "))
         elif opt_type == "unroll-loops":
             newflags.extend(UNROLL_LOOPS_FLAGS.split(" "))
         elif opt_type == "runpath":


### PR DESCRIPTION
## Summary

When building with LTO, disable fat-lto-objects by default in favour of slim LTO objects.

Building with fat LTO objects by default significantly increases build time to catch the rare cases when we do actually ship static files in a package when building with LTO.

Instead, detect any static files or object files containing only LTO bytecode and warn the packager the offending file(s) must be removed or rebuilt with fat-lto-objects.

This way we can significantly reduce build times and disk usage when LTO is enabled.

## Test Plan

Build packages with GCC LTO, clang thin LTO, clang fat LTO, ensure static files built without fat-lto-objects were caught.